### PR TITLE
molpro: 2021.2.1 -> 2024.3.0

### DIFF
--- a/pkgs/apps/molpro/default.nix
+++ b/pkgs/apps/molpro/default.nix
@@ -51,8 +51,8 @@ in stdenv.mkDerivation {
     for bin in ${lib.optionalString (comm == "sockets") "hydra_pmi_proxy mpiexec"} molpro.exe; do
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/$bin
-    done ''
-    + lib.optionalString (comm == "mpipr") ''
+    done
+    '' + lib.optionalString (comm == "mpipr") ''
     for bin in hydra_pmi_proxy mpiexec mpiexec.hydra hydra_bstrap_proxy; do
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/impi/bin/$bin
@@ -62,39 +62,39 @@ in stdenv.mkDerivation {
   doInstallCheck = true;
 
   installCheckPhase = ''
-     #
-     # Minimal check if installation runs properly
-     #
-     inp=water
+    #
+    # Minimal check if installation runs properly
+    #
+    inp=water
 
-     cat << EOF > $inp.inp
-     basis=STO-3G
-     geom = {
-     3
-     Angstrom
-     O       0.000000  0.000000  0.000000
-     H       0.758602  0.000000  0.504284
-     H       0.758602  0.000000 -0.504284
-     }
-     HF
-     EOF
+    cat << EOF > $inp.inp
+    basis=STO-3G
+    geom = {
+    3
+    Angstrom
+    O       0.000000  0.000000  0.000000
+    H       0.758602  0.000000  0.504284
+    H       0.758602  0.000000 -0.504284
+    }
+    HF
+    EOF
 
-     # pretend this is a writable home dir
-     export HOME=$PWD
-     # need to specify interface or: "MPID_nem_tcp_init(373) gethostbyname failed"
-     ${lib.optionalString (comm == "sockets") ''
-       $out/bin/molpro --launcher \
-          "$out/bin/mpiexec -iface lo $out/bin/molpro.exe" $inp.inp
-     ''}
-     ${lib.optionalString (comm == "mpipr") ''
+    # pretend this is a writable home dir
+    export HOME=$PWD
+    # need to specify interface or: "MPID_nem_tcp_init(373) gethostbyname failed"
+    ${lib.optionalString (comm == "sockets") ''
+      $out/bin/molpro --launcher \
+        "$out/bin/mpiexec -iface lo $out/bin/molpro.exe" $inp.inp
+    ''}
+    ${lib.optionalString (comm == "mpipr") ''
       $out/bin/molpro --launcher \
         $out/bin/molpro.exe $inp.inp
-     ''}
+    ''}
 
-     echo "Check for successful run:"
-     grep "RHF STATE 1.1 Energy" $inp.out
-     echo "Check for correct energy:"
-     grep "RHF STATE 1.1 Energy" $inp.out | grep 74.880174
+    echo "Check for successful run:"
+    grep "RHF STATE 1.1 Energy" $inp.out
+    echo "Check for correct energy:"
+    grep "RHF STATE 1.1 Energy" $inp.out | grep 74.880174
   '';
 
   meta = with lib; {

--- a/pkgs/apps/molpro/default.nix
+++ b/pkgs/apps/molpro/default.nix
@@ -1,4 +1,4 @@
-{ lib, stdenv, requireFile, fetchurl, patchelf, python3
+{ lib, stdenv, requireFile, patchelf, python3
 , token
 , comm ? "sockets"
 } :
@@ -7,7 +7,7 @@ assert token != null;
 assert (comm == "sockets") || (comm == "mpipr");
 
 let
-  version = "2021.2.1";
+  version = "2024.3.0";
   url = "http://www.molpro.net";
 
 in stdenv.mkDerivation {
@@ -17,11 +17,11 @@ in stdenv.mkDerivation {
   src = requireFile (if comm == "sockets" then {
     inherit url;
     name = "molpro-mpp-${version}.linux_x86_64_sockets.sh.gz";
-    sha256 = "05ngn0inffng12i3nn820f4cz9g28lz71mi8v5jzvwxbqim0dhds";
+    sha256 = "sha256-3yhUfo/2xYqO8Y22KKpja1kO2JpuV7/lsOBFamOxNUQ=";
   } else {
     inherit url;
     name = "molpro-mpp-${version}.linux_x86_64_mpipr.sh.gz";
-    sha256 = "1hragygrqr3zwimc7c1vv2nkpzgrnjx32xrlsn21r1xgxcp66zni";
+    sha256 = "sha256-mhBhz6SIbbtZ1LcL+sEo33htkVOHYjamPh5db8xPzEs=";
   });
 
   nativeBuildInputs = [ patchelf ];
@@ -48,9 +48,14 @@ in stdenv.mkDerivation {
   postFixup = ''
     #
     # Since version 2019.1 the binaris are dynamically linked
-    for bin in hydra_pmi_proxy molpro.exe mpiexec.hydra; do
+    for bin in ${lib.optionalString (comm == "sockets") "hydra_pmi_proxy mpiexec"} molpro.exe; do
       patchelf \
         --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/bin/$bin
+    done ''
+    + lib.optionalString (comm == "mpipr") ''
+    for bin in hydra_pmi_proxy mpiexec mpiexec.hydra hydra_bstrap_proxy; do
+      patchelf \
+        --set-interpreter "$(cat $NIX_CC/nix-support/dynamic-linker)" $out/impi/bin/$bin
     done
   '';
 
@@ -77,8 +82,14 @@ in stdenv.mkDerivation {
      # pretend this is a writable home dir
      export HOME=$PWD
      # need to specify interface or: "MPID_nem_tcp_init(373) gethostbyname failed"
-     $out/bin/molpro --launcher \
-       "$out/bin/mpiexec.hydra -iface lo $out/bin/molpro.exe" $inp.inp
+     ${lib.optionalString (comm == "sockets") ''
+       $out/bin/molpro --launcher \
+          "$out/bin/mpiexec -iface lo $out/bin/molpro.exe" $inp.inp
+     ''}
+     ${lib.optionalString (comm == "mpipr") ''
+      $out/bin/molpro --launcher \
+        $out/bin/molpro.exe $inp.inp
+     ''}
 
      echo "Check for successful run:"
      grep "RHF STATE 1.1 Energy" $inp.out

--- a/tests/molpro/default.nix
+++ b/tests/molpro/default.nix
@@ -11,7 +11,7 @@ batsTest {
   testScript = ''
     @test "Run-Molpro" {
       ${molpro}/bin/molpro --launcher \
-        "${molpro}/bin/mpiexec.hydra -iface lo
+        "${molpro}/bin/mpiexec -iface lo
         -np $TEST_NUM_CPUS ${molpro}/bin/molpro.exe" \
         molpro.inp
     }
@@ -31,12 +31,12 @@ batsTest {
     }
 
     @test "CASPT2 Energy" {
-      grep '!RSPT2 STATE 1.1 Energy' molpro.out | tail -1 | grep '\-114.3045096'
+      grep '!RSPT2 STATE 1.1 Energy' molpro.out | tail -1 | grep '\-114.304518'
     }
 
     @test "MRCI Energy" {
-      grep '!MRCI STATE 1.1 Energy' molpro.out | grep '\-114.2818399'
-      grep '!MRCI STATE 2.1 Energy' molpro.out | grep '\-114.0268108'
+      grep '!MRCI STATE 1.1 Energy' molpro.out | grep '\-114.281846'
+      grep '!MRCI STATE 2.1 Energy' molpro.out | grep '\-114.026817'
     }
   '';
 }

--- a/tests/molpro/molpro.inp
+++ b/tests/molpro/molpro.inp
@@ -22,9 +22,9 @@ HF
  state,3;
 }
 
-{rs2;noexc;}
+force;
 
-optg
+optg,variable=energy(1)
 
 freq
 


### PR DESCRIPTION
https://www.molpro.net/manual/doku.php?id=recent_changes#new_features_of_molpro20243

The following things have changed:
* The test now fails, since optg/freq optimize to the state averaged energies per default instead of the ground state
* A force statement is required before 
* ~~a direct sequence of opt; freq; does not work any more (at least with numerical gradients). A mcscf block in between is now required.~~
* ~~Analytic gradients (`{rs2;noxec;}`) are unstable, when run in a sandbox. It either fails in optg or freq, but runs fine, when run as user outside the sandbox.~~