### PR TITLE
Infrastructure cleanup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/changedPaths.nix
+++ b/.github/workflows/changedPaths.nix
@@ -20,12 +20,12 @@ let
 
   # Recursive, flattened difference of attribute sets.
   recAttrSetDiff = l: r: lib.attrsets.filterAttrsRecursive
-       (lK: lV: !(builtins.elem lK auxIgnore) && (if lib.hasAttr lK r
-         then lV != r."${lK}"
-         else true)
-       )
-       l
-      ;
+    (lK: lV: !(builtins.elem lK auxIgnore) && (if lib.hasAttr lK r
+    then lV != r."${lK}"
+    else true)
+    )
+    l
+  ;
 
   # Simplify package set
   simplify = as: with lib.attrsets; mapAttrs (_: v: v.drvPath) (filterAttrs (_: v: isDerivation v) as);
@@ -48,7 +48,9 @@ let
   changedPyDerivs = recAttrSetDiff updPyDerivs basPyDerivs;
 
   # For CI purposes we only require the changed attribute keys.
-in { topLevel = builtins.attrNames changedDerivs;
-     python3 = builtins.attrNames changedPyDerivs;
-   }
+in
+{
+  topLevel = builtins.attrNames changedDerivs;
+  python3 = builtins.attrNames changedPyDerivs;
+}
 

--- a/.github/workflows/changedPaths.nix
+++ b/.github/workflows/changedPaths.nix
@@ -12,7 +12,7 @@ let
 
   pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-22.11.tar.gz") { };
 
-  lib = pkgs.lib;
+  inherit (pkgs) lib;
 
   # Ignored outputs, to be removed additionally from the attribute set.
   auxIgnore = [

--- a/.github/workflows/changedPaths.nix
+++ b/.github/workflows/changedPaths.nix
@@ -1,0 +1,54 @@
+updPath: basePath:
+
+let
+  releaseOpts = {
+    config = { };
+    allowUnfree = true;
+    preOverlays = [ ];
+    postOverlays = [ ];
+    buildVariants = false;
+    pin = true;
+  };
+
+  lib = (import "${basePath}/nixpkgs-pin.nix" { }).lib;
+
+  # Ignored outputs, to be removed additionally from the attribute set.
+  auxIgnore = [
+    "channel"
+    "nixexprs"
+  ];
+
+  # Recursive, flattened difference of attribute sets.
+  recAttrSetDiff = l: r: lib.attrsets.filterAttrsRecursive
+       (lK: lV: !(builtins.elem lK auxIgnore) && (if lib.hasAttr lK r
+         then lV != r."${lK}"
+         else true)
+       )
+       l
+      ;
+
+  # Simplify package set
+  simplify = as: with lib.attrsets; mapAttrs (_: v: v.drvPath) (filterAttrs (_: v: isDerivation v) as);
+
+  # Get packages from the updated and base versions
+  updPkgs = (import "${updPath}/release.nix" releaseOpts).qchem;
+  basPkgs = (import "${basePath}/release.nix" releaseOpts).qchem;
+
+  # We are not interested in the realised packages, the derivation paths are
+  # enough and save a lot of time.
+  updDerivs = simplify updPkgs;
+  basDerivs = simplify basPkgs;
+
+  # Handle python packages separately to avoid recursion errors with filterAttrsRecursive
+  updPyDerivs = simplify updPkgs.python3;
+  basPyDerivs = simplify basPkgs.python3;
+
+  # Changed derivations in update
+  changedDerivs = recAttrSetDiff updDerivs basDerivs;
+  changedPyDerivs = recAttrSetDiff updPyDerivs basPyDerivs;
+
+  # For CI purposes we only require the changed attribute keys.
+in { topLevel = builtins.attrNames changedDerivs;
+     python3 = builtins.attrNames changedPyDerivs;
+   }
+

--- a/.github/workflows/changedPaths.nix
+++ b/.github/workflows/changedPaths.nix
@@ -10,7 +10,7 @@ let
     pin = true;
   };
 
-  lib = (import "${basePath}/nixpkgs-pin.nix" { }).lib;
+  lib = (import "${basePath}/nixpkgs-pin.nix" (import <nixpkgs> {})).lib;
 
   # Ignored outputs, to be removed additionally from the attribute set.
   auxIgnore = [

--- a/.github/workflows/changedPaths.nix
+++ b/.github/workflows/changedPaths.nix
@@ -10,7 +10,9 @@ let
     pin = true;
   };
 
-  lib = (import "${basePath}/nixpkgs-pin.nix" (import <nixpkgs> {})).lib;
+  pkgs = import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-22.11.tar.gz") { };
+
+  lib = pkgs.lib;
 
   # Ignored outputs, to be removed additionally from the attribute set.
   auxIgnore = [

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -12,6 +12,6 @@ jobs:
       uses: tj-actions/changed-files@v35
     - uses: cachix/install-nix-action@v20
     - run: |
-      for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
           nix run nixpkgs#editorconfig-checker -- $file
         done

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -15,8 +15,4 @@ jobs:
     - uses: workflow/nix-shell-action@v3
       with:
         packages: editorconfig-checker
-        script: |
-          editorconfig-checker -disable-indent-size ${{ steps.files.outputs.all }}
-    - if: ${{ failure() }}
-      run: |
-        echo "::error :: Hey! It looks like your changes don't follow our editorconfig settings."
+        script: editorconfig-checker -disable-indent-size ${{ steps.files.outputs.all }}

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -6,10 +6,10 @@ jobs:
     name: Editor config check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - id: files
       uses: jitterbit/get-changed-files@v1
-    - uses: cachix/install-nix-action@v16
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - uses: workflow/nix-shell-action@v3

--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -7,12 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - id: files
-      uses: jitterbit/get-changed-files@v1
+    - name: get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v35
     - uses: cachix/install-nix-action@v20
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: workflow/nix-shell-action@v3
-      with:
-        packages: editorconfig-checker
-        script: editorconfig-checker -disable-indent-size ${{ steps.files.outputs.all }}
+    - run: |
+      for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          nix run nixpkgs#editorconfig-checker -- $file
+        done

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -2,34 +2,25 @@ name: basic nix checks
 on: [pull_request]
 
 jobs:
-  run1:
-    name: nix-instantiate
+  # Check if the flake is sane
+  check:
+    name: nix flake check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: files
-      uses: jitterbit/get-changed-files@v1
-    - uses: cachix/install-nix-action@v16
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - run: |
-        nix-instantiate release.nix -A qchem
-  run2:
+      - uses: cachix/install-nix-action@v20
+      - uses: actions/checkout@v3
+      - run: nix flake check --accept-flake-config
+
+  statix:
     name: statix code check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: files
-      uses: jitterbit/get-changed-files@v1
-    - uses: cachix/install-nix-action@v16
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - name: run statix on changed files
-      uses: workflow/nix-shell-action@v3
-      with:
-        packages: statix
-        script: |
-          for file in ${{ steps.files.outputs.all }}; do
-            statix check $file
-          done
-
+    - uses: cachix/install-nix-action@v20
+    - uses: actions/checkout@v3
+    - name: get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+    - run: |
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          nix run nixpkgs#statix -- check $file
+        done

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: cachix/install-nix-action@v20
       - uses: actions/checkout@v3
-      - run: nix flake check --accept-flake-config
+      - run: nix flake check --accept-flake-config --no-build
 
   statix:
     name: statix code check

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       - uses: actions/checkout@v3
       - run: nix-instantiate release.nix -A qchem
 

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -2,6 +2,14 @@ name: basic nix checks
 on: [pull_request]
 
 jobs:
+  instantiate:
+    name: nix-instantiate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cachix/install-nix-action@v20
+      - uses: actions/checkout@v3
+      - run: nix-instantiate release.nix -A qchem
+
   # Check if the flake is sane
   check:
     name: nix flake check

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -57,9 +57,15 @@ jobs:
         with:
           name: Changed-Derivations
       # Rebuild all changed python3 packages
-      - run: nix build --accept-flake-config $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      - run: |
+          if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+          fi
       # Rebuild all changed top-level packages
-      - run: nix build --accept-flake-config $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+      - run: |
+          if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+          fi
 
   # Rebuild changed derivations for nixpkgs-unstable
   rebuild-unstable:
@@ -80,9 +86,15 @@ jobs:
         with:
           name: Changed-Derivations
       # Rebuild all changed python3 packages
-      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      - run: |
+          if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+          fi
       # Rebuild all changed top-level packages
-      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+      - run: |
+          if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+          fi
 
   # Rebuild changed derivations for nixpkgs/master
   rebuild-master:
@@ -103,6 +115,12 @@ jobs:
         with:
           name: Changed-Derivations
       # Rebuild all changed python3 packages
-      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      - run: |
+          if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+          fi
       # Rebuild all changed top-level packages
-      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+      - run: |
+          if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+          fi

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -59,12 +59,12 @@ jobs:
       # Rebuild all changed python3 packages
       - run: |
           if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+            nix build --accept-flake-config --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
           fi
       # Rebuild all changed top-level packages
       - run: |
           if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+            nix build --accept-flake-config --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi
 
   # Rebuild changed derivations for nixpkgs-unstable
@@ -88,12 +88,12 @@ jobs:
       # Rebuild all changed python3 packages
       - run: |
           if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
           fi
       # Rebuild all changed top-level packages
       - run: |
           if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi
 
   # Rebuild changed derivations for nixpkgs/master
@@ -117,10 +117,10 @@ jobs:
       # Rebuild all changed python3 packages
       - run: |
           if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
           fi
       # Rebuild all changed top-level packages
       - run: |
           if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+            nix build --accept-flake-config --override-input nixpkgs nixpkgs/master --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -1,47 +1,106 @@
-name: nix rebuilds
+name: rebuilds
 on: [pull_request]
 
 jobs:
-  run:
-    name: Calculate changed outputs
+  # Calculate changed derivations
+  get-changed-derivs:
+    name: Get changed derivations
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        path: pr
-    - uses: actions/checkout@v2
-      with:
-        path: master
-        ref: master
-    - uses: cachix/install-nix-action@v16
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - name: Changed paths
-      run: |
-        cat /etc/nix/nix.conf
-        id
-        echo $NIX_PATH
-        nix-channel --add https://nixos.org/channels/nixos-21.11 nixpkgs
-        nix-channel --update
-        nix-instantiate ./pr/release.nix -A qchem
-        nix-env -f ./pr/release.nix -qaP --no-name --out-path --show-trace \
-          --option binary-caches 'https://cache.nixos.org/ https://nix-qchem.cachix.org/' \
-          --option trusted-public-keys '
-            nix-qchem.cachix.org-1:ZjRh1PosWRj7qf3eukj4IxjhyXx6ZwJbXvvFk3o3Eos=
-            cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          ' --arg allowUnfree false -A qchem | sort > paths-pr
-        nix-instantiate ./master/release.nix -A qchem
-        nix-env -f ./master/release.nix -qaP --no-name --out-path --show-trace \
-          --option binary-caches 'https://cache.nixos.org/ https://nix-qchem.cachix.org/' \
-          --option trusted-public-keys '
-            nix-qchem.cachix.org-1:ZjRh1PosWRj7qf3eukj4IxjhyXx6ZwJbXvvFk3o3Eos=
-            cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          ' --arg allowUnfree false -A qchem | sort > paths-master
-        diff -u paths-master paths-pr | grep -E "^\+" | sed '/^+++/d; s/^+//' | tee > changed_outputs
-        echo "The following outputs need to be rebuild:" > changed_outputs.md
-        awk '{ print $1 }' changed_outputs | sed 's/\(.*\)/- \1/' >> changed_outputs.md
-    - uses: machine-learning-apps/pr-comment@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        path: changed_outputs.md
+      # Install Nix on the runner
+      - uses: cachix/install-nix-action@v20
+      # Pull from the cachix cache
+      - uses: cachix/cachix-action@v12
+        with:
+          name: nix-qchem
+      # Checkout of the current head in the working dir
+      - uses: actions/checkout@v3
+      # Get PR target branch checkout
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          repository: ${{ github.event.pull_request.base.repo.full_name }}
+          path: pr_base
+      # Get a checkout of this PR
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          path: pr_head
+      # Calculate changed derivations and upload as artifacts
+      - run: nix eval --impure --expr 'import ./.github/workflows/changedPaths.nix ./pr_head ./pr_base' --json | tee chDerivs.json
+      # Upload JSON of the changed derivations
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Changed-Derivations
+          path: chDerivs.json
+          retention-days: 1
+
+  # Rebuild changed derivations for the pinned snapshot
+  rebuild-pin:
+    name: Pinned
+    needs: get-changed-derivs
+    runs-on: ubuntu-latest
+    steps:
+      # Install Nix on the runner
+      - uses: cachix/install-nix-action@v20
+      # Pull from the cachix cache
+      - uses: cachix/cachix-action@v12
+        with:
+          name: nix-qchem
+      # Checkout of the current head in the working dir
+      - uses: actions/checkout@v3
+      # Get changed derivations as artifact from previous step
+      - uses: actions/download-artifact@v3
+        with:
+          name: Changed-Derivations
+      # Rebuild all changed python3 packages
+      - run: nix build --accept-flake-config $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      # Rebuild all changed top-level packages
+      - run: nix build --accept-flake-config $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+
+  # Rebuild changed derivations for nixpkgs-unstable
+  rebuild-unstable:
+    name: Unstable
+    needs: get-changed-derivs
+    runs-on: ubuntu-latest
+    steps:
+      # Install Nix on the runner
+      - uses: cachix/install-nix-action@v20
+      # Pull from the cachix cache
+      - uses: cachix/cachix-action@v12
+        with:
+          name: nix-qchem
+      # Checkout of the current head in the working dir
+      - uses: actions/checkout@v3
+      # Get changed derivations as artifact from previous step
+      - uses: actions/download-artifact@v3
+        with:
+          name: Changed-Derivations
+      # Rebuild all changed python3 packages
+      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      # Rebuild all changed top-level packages
+      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
+
+  # Rebuild changed derivations for nixpkgs/master
+  rebuild-master:
+    name: Master
+    needs: get-changed-derivs
+    runs-on: ubuntu-latest
+    steps:
+      # Install Nix on the runner
+      - uses: cachix/install-nix-action@v20
+      # Pull from the cachix cache
+      - uses: cachix/cachix-action@v12
+        with:
+          name: nix-qchem
+      # Checkout of the current head in the working dir
+      - uses: actions/checkout@v3
+      # Get changed derivations as artifact from previous step
+      - uses: actions/download-artifact@v3
+        with:
+          name: Changed-Derivations
+      # Rebuild all changed python3 packages
+      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
+      # Rebuild all changed top-level packages
+      - run: nix build --accept-flake-config --override-input nixpkgs nixpkgs/master $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       # Install Nix on the runner
       - uses: cachix/install-nix-action@v20
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
       # Pull from the cachix cache
       - uses: cachix/cachix-action@v12
         with:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,4 +1,4 @@
-name: basic code checks
+name: basic spell checks
 on: [pull_request]
 
 jobs:
@@ -6,16 +6,13 @@ jobs:
     name: Spell check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: files
-      uses: jitterbit/get-changed-files@v1
-    - uses: cachix/install-nix-action@v16
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - name: check for typos
-      uses: workflow/nix-shell-action@v3
-      with:
-        packages: typos
-        script: |
-          typos $(echo "${{ steps.files.outputs.all }}" | tr ' ' '\n' | sed 's:\(.*\):./\1:' | tr '\n' ' ')
+    - uses: actions/checkout@v3
+    - name: get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v35
+    - uses: cachix/install-nix-action@v20
+    - run: |
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          nix run nixpkgs#typos -- $(echo "${{ steps.files.outputs.all }}" | tr ' ' '\n' | sed 's:\(.*\):./\1:' | tr '\n' ' ')
+        done
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+result*
+.direnv/

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
               vmd = null;
               mesa-qc = null;
               mcdth = null;
+              nixGL = null;
             };
           })
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,7 @@
 
       overlays = {
         qchem = qchemOvl;
+        qchem' = import ./default.nix;
         pythonQchem = import ./pythonPackages.nix pkgs.config.qchem-config.prefix pkgs.config.qchem-config pkgs nixpkgs;
         default = self.overlays.qchem;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,11 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-  nixConfig.extra-substituters = [ "https://nix-qchem.cachix.org" ];
+  nixConfig = {
+    extra-substituters = [ "https://nix-qchem.cachix.org" ];
+
+    allow-import-from-derivation = "true";
+  };
 
   outputs = { self, nixpkgs, ... }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,14 @@
 
       checks."${system}" = with lib; filterAttrs (n: isDerivation) pkgs.qchem.tests;
 
+      formatter."${system}" = pkgs.nixpkgs-fmt;
+
+      devShells."${system}".default = with pkgs; mkShell {
+        buildInputs = [
+          self.formatter."${system}"
+          statix
+        ];
+      };
 
       overlays = {
         qchem = qchemOvl;

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -1,21 +1,21 @@
-subset: cfg: selfPkgs: superPkgs: self: super:
+subset: cfg: finalPkgs: prevPkgs: final: prev:
 
 let
   callPackage = lib.callPackageWith (
-    selfPkgs.pkgs //  # nixpkgs
-    selfPkgs //       # overlay
-    self //           # python
+    finalPkgs.pkgs //  # nixpkgs
+    finalPkgs //       # overlay
+    final //           # python
     overlay );
 
-  inherit (selfPkgs.pkgs) lib;
+  inherit (finalPkgs.pkgs) lib;
 
   overlay = {
 
-  } // lib.optionalAttrs super.isPy3k {
+  } // lib.optionalAttrs prev.isPy3k {
     adcc = callPackage ./pkgs/apps/adcc { };
 
     dftbplus = callPackage ./pkgs/apps/dftbplus {
-      inherit (selfPkgs) tblite;
+      inherit (finalPkgs) tblite;
     };
 
     pyqdng = callPackage ./pkgs/apps/pyQDng { };
@@ -26,7 +26,7 @@ let
 
     moltemplate = callPackage ./pkgs/apps/moltemplate { };
 
-    openmm = superPkgs.openmm.override {
+    openmm = prevPkgs.openmm.override {
       enablePython = true;
       enableCuda = cfg.useCuda;
     };
@@ -40,13 +40,13 @@ let
     pylibefp = callPackage ./pkgs/lib/pylibefp { };
 
     psi4 = callPackage ./pkgs/apps/psi4 {
-      libint = superPkgs.libintPsi4;
+      libint = prevPkgs.libintPsi4;
     };
 
     pychemps2 = callPackage ./pkgs/apps/chemps2/PyChemMPS2.nix { };
 
     pysisyphus = callPackage ./pkgs/apps/pysisyphus {
-      gamess-us = selfPkgs.gamess-us.override {
+      gamess-us = finalPkgs.gamess-us.override {
         enableMpi = false;
       };
     };
@@ -54,8 +54,8 @@ let
     pyphspu = callPackage ./pkgs/lib/pyphspu { };
 
     tblite = callPackage ./pkgs/lib/tblite/python.nix {
-      inherit (selfPkgs) tblite;
-      inherit (superPkgs) meson;
+      inherit (finalPkgs) tblite;
+      inherit (prevPkgs) meson;
     };
 
     veloxchem = callPackage ./pkgs/apps/veloxchem { };
@@ -63,7 +63,7 @@ let
     vermouth = callPackage ./pkgs/apps/vermouth { };
 
     xtb-python = callPackage ./pkgs/lib/xtb-python { };
-  } // lib.optionalAttrs super.isPy27 {
+  } // lib.optionalAttrs prev.isPy27 {
     pyquante = callPackage ./pkgs/apps/pyquante { };
   };
 


### PR DESCRIPTION
This PR is meant to address some challenges of infrastructural nature and meant to clean up a few things and update a few of our workflows.

# Goals
* [x] Make the flake pass all checks of `nix flake check`
* [x] Provide development tools to write work with the overlay in the `devShells` output attribute, including direnv integration
* [x] New and stable mechanism to find changed packages
* [x] Build changed packages via GitHub actions
* [ ] ~~Push build artifacts from the GitHub actions to Cachix~~
* [ ] Integrate on-site GitHub runner with more powerful hardware and local cache

# Open Questions
* On-site GitHub runners could build and test proprietary packages we would have access to, provided we use the `srcurl` mechanism and the GitHub runner machine has access to that respective host. In our setup this should be possible without problems. Our GitHub runner machine would be in the same subnet as the file server. However, I am not entirely sure if we _should_ do this. It would require some protection mechanism of who is allowed to trigger pipelines.
* Currently, we are using the `null` overlay to disable some proprietary packages in the flake. Is this strictly necessary? I think it does no harm exposing common unfree packages. To avoid their tests failing I would rather filter the tests?