### PR TITLE
optking: fix commit+hash

### DIFF
--- a/pkgs/lib/optking/default.nix
+++ b/pkgs/lib/optking/default.nix
@@ -14,7 +14,7 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "psi-rking";
     repo = "optking";
-    rev = version;
+    rev = "3025f85c47df308c4482341129db9ad5ebc82c6a"; # Tag keeps moving
     hash = "sha256-mXLBsc4PQjeTjUg0nzf9PI0FF81y77yCJ5l+g47uoD8=";
   };
 


### PR DESCRIPTION
Optking has moved the tag again. I am fixing the commit now.