### PR TITLE
github/nix-rebuild: add names to job steps

### DIFF
--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -69,35 +69,6 @@ jobs:
             nix build --accept-flake-config --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi
 
-  # Rebuild changed derivations for nixpkgs-unstable
-  rebuild-unstable:
-    name: Unstable
-    needs: get-changed-derivs
-    runs-on: ubuntu-latest
-    steps:
-      # Install Nix on the runner
-      - uses: cachix/install-nix-action@v20
-      # Pull from the cachix cache
-      - uses: cachix/cachix-action@v12
-        with:
-          name: nix-qchem
-      # Checkout of the current head in the working dir
-      - uses: actions/checkout@v3
-      # Get changed derivations as artifact from previous step
-      - uses: actions/download-artifact@v3
-        with:
-          name: Changed-Derivations
-      # Rebuild all changed python3 packages
-      - run: |
-          if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
-          fi
-      # Rebuild all changed top-level packages
-      - run: |
-          if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
-            nix build --accept-flake-config --override-input nixpkgs nixpkgs/nixpkgs-unstable --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
-          fi
-
   # Rebuild changed derivations as if merged
   rebuild-merge:
     name: Changed Derivations Merge (pinned nixpkgs)

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -52,6 +52,8 @@ jobs:
           name: nix-qchem
       # Checkout of the current head in the working dir
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       # Get changed derivations as artifact from previous step
       - uses: actions/download-artifact@v3
         with:
@@ -110,9 +112,6 @@ jobs:
           name: nix-qchem
       # Checkout merge commit as if PR would already be merged
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.sha }}
-          repository: ${{ github.event.pull_request.base.repo.full_name }}
       # Get changed derivations as artifact from previous step
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -29,8 +29,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           path: pr_head
-      # Calculate changed derivations and upload as artifacts
-      - run: nix eval --impure --expr 'import ./.github/workflows/changedPaths.nix ./pr_head ./pr_base' --json | tee chDerivs.json
+      - name: Calculate changed derivations and upload as artifacts
+        run: nix eval --impure --expr 'import ./.github/workflows/changedPaths.nix ./pr_head ./pr_base' --json | tee chDerivs.json
       # Upload JSON of the changed derivations
       - uses: actions/upload-artifact@v3
         with:
@@ -39,8 +39,8 @@ jobs:
           retention-days: 1
 
   # Rebuild changed derivations for the pinned snapshot
-  rebuild-pin:
-    name: Pinned
+  rebuild-head:
+    name: Changed derivations HEAD (pinned nixpkgs)
     needs: get-changed-derivs
     runs-on: ubuntu-latest
     steps:
@@ -56,13 +56,13 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: Changed-Derivations
-      # Rebuild all changed python3 packages
-      - run: |
+      - name: Rebuild python3 packages
+        run: |
           if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
             nix build --accept-flake-config --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
           fi
-      # Rebuild all changed top-level packages
-      - run: |
+      - name: Rebuild all top-level packages
+        run: |
           if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
             nix build --accept-flake-config --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi
@@ -97,8 +97,8 @@ jobs:
           fi
 
   # Rebuild changed derivations as if merged
-  rebuild-master:
-    name: Master
+  rebuild-merge:
+    name: Changed Derivations Merge (pinned nixpkgs)
     needs: get-changed-derivs
     runs-on: ubuntu-latest
     steps:
@@ -117,13 +117,13 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: Changed-Derivations
-      # Rebuild all changed python3 packages
-      - run: |
+      - name: Rebuild all changed python3 packages
+        run: |
           if [ -n "$(jq '.python3[]' chDerivs.json)" ]; then
             nix build --accept-flake-config --print-build-logs $(for p in $(jq '.python3[]' chDerivs.json | tr -d "\""); do echo ".#python3.pkgs.${p}"; done)
           fi
-      # Rebuild all changed top-level packages
-      - run: |
+      - name: Rebuild all changed top-level packages
+        run: |
           if [ -n "$(jq '.topLevel[]' chDerivs.json)" ]; then
             nix build --accept-flake-config --print-build-logs $(for p in $(jq '.topLevel[]' chDerivs.json | tr -d "\""); do echo ".#${p}"; done)
           fi


### PR DESCRIPTION
Let's try if we can add names to the job steps. That would make the runner output more readable.

Changes:
* Added naming to the job steps to increase readability in on PR page and actions page (detailed listing).
* The default of the checkout action is to check out the merge commit. HEAD is now HEAD of the PR and Merge is the merge commit.
*  Removed the nixpkgs-unstable rebuild job. This is a projection into the future that may be nice to have, but not sure if it's worth the resource usage.