### PR TITLE
python.vermouth/polyply: fix build

### DIFF
--- a/pkgs/apps/polyply/default.nix
+++ b/pkgs/apps/polyply/default.nix
@@ -23,7 +23,8 @@ buildPythonPackage rec {
 
   postPatch = ''
     substituteInPlace setup.cfg \
-      --replace "decorator == 4.4.2" ""
+      --replace "decorator == 4.4.2" "" \
+      --replace 'networkx ~= 2.0' 'networkx'
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/apps/vermouth/default.nix
+++ b/pkgs/apps/vermouth/default.nix
@@ -11,6 +11,10 @@ buildPythonPackage rec {
     hash = "sha256-Ix17LRY8f9z9UBDELbpaIO7Tt2SvxKtIXr0kgCV24cE=";
   };
 
+  postPatch = ''
+    substituteInPlace ./setup.cfg --replace 'networkx ~= 2.0' 'networkx'
+  '';
+
   nativeBuildInputs = [ pbr ];
   propagatedBuildInputs = [
     numpy


### PR DESCRIPTION
Remove constraint for networkx 2.0. `networkx` has been updated to version 3.0 (https://github.com/NixOS/nixpkgs/pull/218614).
Both packages just build fine and polyply passes all tests.
@sheepforce can you check if that fix is okay?