### PR TITLE
Update flake.lock, 1.2.2 -> 1.2.2-2022-06-03

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685399834,
-        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
+        "lastModified": 1686398752,
+        "narHash": "sha256-nGWNQVhSw4VSL+S0D0cbrNR9vs9Bq7rlYR+1K5f5j6w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
+        "rev": "a30520bf8eabf8a5c37889d661e67a2dbcaa59e6",
         "type": "github"
       },
       "original": {

--- a/overlay.nix
+++ b/overlay.nix
@@ -116,12 +116,10 @@ let
         autoint = super.python3.pkgs.toPythonApplication self.python3.pkgs.pyphspu;
 
         bagel = callPackage ./pkgs/apps/bagel {
-          boost = final.boost16x;
         };
 
         bagel-serial = callPackage ./pkgs/apps/bagel {
           enableMpi = false;
-          boost = final.boost16x;
         };
 
         cefine = self.nullable self.turbomole (callPackage ./pkgs/apps/cefine { });

--- a/pkgs/apps/bagel/default.nix
+++ b/pkgs/apps/bagel/default.nix
@@ -10,9 +10,9 @@
 let
   mpiName = mpi.pname;
   mpiType = if mpiName == "openmpi" then mpiName
-       else if mpiName == "mpich"  then "mvapich"
-       else if mpiName == "mvapich"  then mpiName
-       else throw "mpi type ${mpiName} not supported";
+    else if mpiName == "mpich"  then "mvapich"
+    else if mpiName == "mvapich"  then mpiName
+    else throw "mpi type ${mpiName} not supported";
 
   useMKL = blas.passthru.implementation == "mkl" && lapack.passthru.implementation == "mkl";
 
@@ -54,10 +54,10 @@ in stdenv.mkDerivation rec {
   BOOST_ROOT=boost;
 
   configureFlags = with lib; [ "--with-boost=${boost}" ]
-                   ++ optional enableMpi "--with-mpi=${mpiType}"
-                   ++ optional ( !enableMpi ) "--disable-smith"
-                   ++ optional ( !enableScalapack ) "--disable-scalapack"
-                   ++ optional useMKL"--enable-mkl";
+    ++ optional enableMpi "--with-mpi=${mpiType}"
+    ++ optional ( !enableMpi ) "--disable-smith"
+    ++ optional ( !enableScalapack ) "--disable-scalapack"
+    ++ optional useMKL"--enable-mkl";
 
   preConfigure = ''
     ./autogen.sh

--- a/pkgs/apps/bagel/default.nix
+++ b/pkgs/apps/bagel/default.nix
@@ -1,5 +1,5 @@
 { stdenv, lib, fetchFromGitHub, autoconf, automake, libtool
-, makeWrapper, openssh, fetchpatch
+, makeWrapper, openssh
 , python3, boost, blas, lapack
 , enableMpi ? true
 , mpi
@@ -18,23 +18,18 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "bagel";
-  version = "1.2.2";
+  version = "1.2.2-2022-06-03";
 
   src = fetchFromGitHub {
     owner = "nubakery";
     repo = "bagel";
-    rev = "v${version}";
-    sha256 = "184p55dkp49s99h5dpf1ysyc9fsarzx295h7x0id8y0b1ggb883d";
+    rev = "2955e4d1a17b2855c028f828ce48fc10d76e3cf5";
+    sha256 = "sha256-mRfG2FP9ZHniZO2MBJqi7Bl5kAjD8WQ5W6nD33kjp+Y=";
   };
 
-  # Required for gcc >= 10
-  patches = [ (fetchpatch {
-    name = "gcc-11";
-    url = "https://salsa.debian.org/debichem-team/bagel/-/raw/629c8b4869c707cae76503706806f09c132c6883/debian/patches/fix_gcc_11_build_failure.patch";
-    sha256 = "0kvnlzs5ili4l728z8rirhn5xf4c30cabiijzzivcjxqbvxdb8b0";
-  })];
+  nativeBuildInputs = [ autoconf automake libtool ];
+  checkInputs = [ openssh ];
 
-  nativeBuildInputs = [ autoconf automake libtool openssh boost ];
   buildInputs = [
     python3
     boost
@@ -63,11 +58,6 @@ in stdenv.mkDerivation rec {
                    ++ optional ( !enableMpi ) "--disable-smith"
                    ++ optional ( !enableScalapack ) "--disable-scalapack"
                    ++ optional useMKL"--enable-mkl";
-
-  postPatch = ''
-    # Fixed upstream
-    sed -i '/using namespace std;/i\#include <string.h>' src/util/math/algo.cc
-  '';
 
   preConfigure = ''
     ./autogen.sh


### PR DESCRIPTION
Boost 16x has been removed in 648efce549ee3b00ba9ffcb2c44c3c7197ea46fe, breaking bagel.
Bagel contains a lot of bugfixes, also for boost and newer gcc compilers on its master branch.