### PR TITLE
gamess: down grade gfortran to version 10

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -155,7 +155,7 @@ let
 
         gamess-us = callPackage ./pkgs/apps/gamess-us {
           blas = final.blas-ilp64;
-          gfortran = final.gfortran11;
+          gfortran = final.gfortran10;
         };
 
         gator = super.python3.pkgs.toPythonApplication self.python3.pkgs.gator;


### PR DESCRIPTION
gfortran 11.4 does not seem to be support anymore