### PR TITLE
bagel: turn off cpu pinning in checkPhase

### DIFF
--- a/pkgs/apps/bagel/default.nix
+++ b/pkgs/apps/bagel/default.nix
@@ -76,6 +76,7 @@ in stdenv.mkDerivation rec {
     export OMP_NUM_THREADS=1
     export OMPI_MCA_rmaps_base_oversubscribe=1
     export MV2_ENABLE_AFFINITY=0
+    export OMPI_MCA_hwloc_base_binding_policy=none
     # Fix to make mpich run in a sandbox
     export HYDRA_IFACE=lo
 


### PR DESCRIPTION
openmpi jobs block each other by all binding to CPUs 0 and 1