### PR TITLE
flake: disable gaussview in packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
               cefine = null;
               cfour = null;
               gamess-us = null;
+              gaussview = null;
               mrcc = null;
               orca = null;
               qdng = null;


### PR DESCRIPTION
Gaussview is not disabled by default as the other unfree packages in the exported flake outputs, resulting in Hydra failures and a formal inconsistency. Have disabled it, too.