### PR TITLE
flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1691003216,
-        "narHash": "sha256-Qq/MPkhS12Bl0X060pPvX3v9ac3f2rRQfHjjozPh/Qs=",
+        "lastModified": 1691403902,
+        "narHash": "sha256-J74y4xWtKPDPyVtF4arzrwuSOGznlFlJ+uB9RwNNnbo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4a56ce9727a0c5478a836a0d8a8f641c5b9a3d5f",
+        "rev": "c91024273f020df2dcb209cc133461ca17848026",
         "type": "github"
       },
       "original": {

--- a/overlay.nix
+++ b/overlay.nix
@@ -186,10 +186,7 @@ let
           };
         in molcasOpt.overrideAttrs (oldAttrs: {
           buildInputs = oldAttrs.buildInputs ++ [ self.chemps2 ];
-          cmakeFlags = oldAttrs.cmakeFlags ++ [
-            "-DWFA=ON"
-            "-DCHEMPS2=ON" "-DCHEMPS2_DIR=${self.chemps2}/bin"
-          ];
+          cmakeFlags = oldAttrs.cmakeFlags ++ [ "-DWFA=ON" ];
 
           # Needed by libwfa
           CXXFLAGS = [ "-DH5_USE_110_API" ];


### PR DESCRIPTION
Another flake.lock update with the DMRG/QCMaquis support from upstream https://github.com/NixOS/nixpkgs/pull/246983

Molcas supports only one DMRG solver at a given time and thus I've disabled CheMPS2 in our local Molcas version. The QCMaquis support is much more powerful in Molcas.