### PR TITLE
XTBPATH

### DIFF
--- a/pkgs/apps/crest/default.nix
+++ b/pkgs/apps/crest/default.nix
@@ -37,7 +37,8 @@ stdenv.mkDerivation rec {
   postFixup = ''
     wrapProgram $out/bin/crest \
       --prefix PATH : "${xtb}/bin" \
-      --prefix PATH : "${xtb-iff}/bin"
+      --prefix PATH : "${xtb-iff}/bin" \
+      --set-default XTBPATH ${xtb}/share/xtb
   '';
 
   meta = with lib; {

--- a/pkgs/apps/xtb-iff/default.nix
+++ b/pkgs/apps/xtb-iff/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, fetchurl, autoPatchelfHook }:
+{ stdenv, lib, fetchurl, autoPatchelfHook, makeWrapper, xtb }:
 
 stdenv.mkDerivation rec {
   pname = "xtb-iff";
@@ -17,6 +17,8 @@ stdenv.mkDerivation rec {
     runHook postUnpack
   '';
 
+  nativeBuildInputs = [ makeWrapper ];
+
   dontConfigure = true;
   dontBuild = true;
 
@@ -27,6 +29,11 @@ stdenv.mkDerivation rec {
     install xtbiff $out/bin
 
     runHook postInstall
+  '';
+
+  postFixup = ''
+    wrapProgram $out/bin/xtbiff \
+      --set-default XTBPATH ${xtb}/share/xtb
   '';
 
   meta = with lib; {

--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -83,15 +83,14 @@ stdenv.mkDerivation rec {
 
   postFixup = ''
     wrapProgram $out/bin/xtb \
-      --prefix PATH : "${binSearchPath}"
+      --prefix PATH : "${binSearchPath}" \
+      --set-default XTBPATH $out/share/xtb
   '';
 
   doCheck = true;
   preCheck = ''
     export OMP_NUM_THREADS=2
   '';
-
-  setupHooks = [ ./xtbHook.sh ];
 
   passthru = { inherit enableOrca enableTurbomole; };
 

--- a/pkgs/apps/xtb/xtbHook.sh
+++ b/pkgs/apps/xtb/xtbHook.sh
@@ -1,1 +1,0 @@
-export XTBPATH=@out@/share/xtb


### PR DESCRIPTION
Some time ago the setup hooks stopped working, e.g. the XTBPATH hook. This PR sets the required `XTBPATH` variables via the wrapper for all executables, instead.