### PR TITLE
xtb-python: fix meson.build

### DIFF
--- a/pkgs/lib/xtb-python/default.nix
+++ b/pkgs/lib/xtb-python/default.nix
@@ -24,6 +24,13 @@ buildPythonPackage rec {
     hash = "sha256-TTVtPVhb7FJnvu/C2yJhxOE/KzuLxe0N4HbpbkE/MTM=";
   };
 
+  postPatch = ''
+    substituteInPlace meson.build \
+      --replace "get_option('python_version')," "get_option('python_version'), pure: false,"
+
+    cat meson.build
+  '';
+
   nativeBuildInputs = [ meson ninja pkg-config meson-python ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
From the xtb-python readme:

```
This repository hosts the Python API for the extended tight binding (xtb) program.

    Warning ⚠️ : xtb-python is no longer in active development. We recommend using [tblite](https://github.com/tblite/tblite) instead.

The idea of this project is to provide the xtb API for Python without requiring an additional xtb installation.
```

If it fails in the future and fixing becomes too complex I think we should just mark it as broken.