### PR TITLE
overlay: fix system impurity

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,7 @@ let
 
   pkgs = nixpkgs {
     overlays = [ (import ./overlay.nix) ];
-    inherit (prev) config;
+    inherit (prev) config system;
   };
 
 in


### PR DESCRIPTION
The pinned overlay `default.nix` exposed via the flake as `overlays.qchem'` throws an error in a pure flake evaluation as we did not specify the `system` architecture in `default.nix`. This should be fixed by this PR.