### PR TITLE
batsTests: diasable MPI CPU pinning

### DIFF
--- a/builders/batsTest.nix
+++ b/builders/batsTest.nix
@@ -111,6 +111,9 @@ in stdenvNoCC.mkDerivation ({
       echo " $orgName"
       cp $f $orgName
     done
+
+    export OMPI_MCA_hwloc_base_binding_policy=none
+    export MV2_ENABLE_AFFINITY=0
   '';
 
   runPhase = ''


### PR DESCRIPTION
Avoid blockage of Hydra when multiple test occupy CPU cores 0 and 1