### PR TITLE
Poltype2

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -233,6 +233,8 @@ let
 
         pdbfixer = super.python3.pkgs.toPythonApplication self.python3.pkgs.pdbfixer;
 
+        poltype2 = callPackage ./pkgs/apps/poltype2 { };
+
         polyply = super.python3.pkgs.toPythonApplication self.python3.pkgs.polyply;
 
         psi4 = super.python3.pkgs.toPythonApplication self.python3.pkgs.psi4;

--- a/pkgs/apps/poltype2/default.nix
+++ b/pkgs/apps/poltype2/default.nix
@@ -1,0 +1,53 @@
+{ micromamba
+, lib
+, fetchFromGitHub
+, buildFHSUserEnv
+  # Runtime executable dependencies
+, perl
+, tinker
+, psi4
+, xtb
+, gdma
+, autodock-vina
+}:
+
+let
+  pname = "poltype2";
+  version = "unstable-2023-09-09";
+
+  src = fetchFromGitHub {
+    owner = "TinkerTools";
+    repo = pname;
+    rev = "3497187";
+    hash = "sha256-Qu2g97zbdOZT6jsR2k+Xarfj9AKs252aLlgPi8JTd/8=";
+  };
+
+in
+buildFHSUserEnv {
+  name = "poltype";
+
+  targetPkgs = pkgs: (with pkgs; [
+    micromamba
+    bashInteractive
+    tinker
+    xtb
+    gdma
+    autodock-vina
+    perl
+  ]);
+
+  profile = ''
+    eval "$(micromamba shell hook -s bash)"
+    MAMBA="''${MAMBA_ROOT:-$(mktemp -d)}"
+    export MAMBA_ROOT_PREFIX=$MAMBA/.mamba
+    if [ -f $MAMBA/environment.yml ]; then
+      chmod +w $MAMBA/environment.yml && rm $MAMBA/environment.yml
+    fi
+    cp ${src}/Environments/environment.yml $MAMBA/.
+    export GDMADIR=${gdma}/bin
+    export PSI_SCRATCH="''${PSI_TMP:-$(mktemp -d)}"
+    micromamba env create --yes -f $MAMBA/environment.yml
+  '';
+
+  runScript = "micromamba run -n amoebamdpoltype python ${src}/PoltypeModules/poltype.py";
+}

--- a/pkgs/apps/tinker/default.nix
+++ b/pkgs/apps/tinker/default.nix
@@ -1,12 +1,19 @@
-{ stdenv, lib, fetchurl, gfortran, cmake, fftw, pkg-config } :
+{ stdenv
+, lib
+, fetchurl
+, gfortran
+, cmake
+, fftw
+, pkg-config
+}:
 
 stdenv.mkDerivation rec {
   pname = "tinker";
-  version = "8.10.1";
+  version = "8.10.5";
 
-  src = fetchurl  {
+  src = fetchurl {
     url = "https://dasher.wustl.edu/tinker/downloads/tinker-${version}.tar.gz";
-    hash = "sha256-RofWDMRMg0YqFWOZIMSn/lUa7GtB8pXJOWLYO/TvTys=";
+    hash = "sha256-RnN4Px2PNpyekK3W+L5K64ppaVJf2MCbb5e3ypMpTpQ=";
   };
 
   preConfigure = ''
@@ -33,7 +40,7 @@ stdenv.mkDerivation rec {
 
   meta = with lib; {
     description = "Software Tools for Molecular Design";
-    homepage = "https://dasher.wustl.edu/tinker/";
+    homepage = "https://github.com/TinkerTools/tinker";
     license = licenses.unfree;
     platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];

--- a/pkgs/lib/mdtraj/default.nix
+++ b/pkgs/lib/mdtraj/default.nix
@@ -1,0 +1,51 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, setuptools
+, cython
+, numpy
+, scipy
+, pyparsing
+, astunparse
+, zlib
+}:
+
+buildPythonPackage rec {
+  pname = "mdtraj";
+  version = "1.9.9";
+
+  src = fetchFromGitHub {
+    owner = "mdtraj";
+    repo = pname;
+    rev = version;
+    hash = "sha256-2Jg6DyVJlRBLD/6hMtcsrAdxKF5RkpUuhAQm/lqVGeE=";
+  };
+
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace "oldest-supported-numpy" "numpy" \
+      --replace "Cython~=0.29.36" "Cython"
+  '';
+
+  format = "pyproject";
+
+  buildInputs = [ zlib ];
+
+  propagatedBuildInputs = [
+    setuptools
+    cython
+    numpy
+    pyparsing
+    astunparse
+    scipy
+  ];
+
+  pythonImportsCheck = [ "mdtraj" ];
+
+  meta = with lib; {
+    description = "Open library for the analysis of molecular dynamics trajectories";
+    homepage = "https://github.com/mdtraj/mdtraj";
+    license = licenses.lgpl21Plus;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/mendeleev/default.nix
+++ b/pkgs/lib/mendeleev/default.nix
@@ -1,0 +1,50 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, colorama
+, pyfiglet
+, pygments
+, pandas
+, sqlalchemy
+, bokeh
+, plotly
+, seaborn
+, poetry-core
+}:
+
+buildPythonPackage rec {
+  pname = "mendeleev";
+  version = "0.14.0";
+
+  src = fetchFromGitHub {
+    owner = "lmmentel";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-iVOc2O+Pavc5nlzuwe3HpP0H2Esif8vhQWtTLT/pBjA=";
+  };
+
+  format = "pyproject";
+
+  propagatedBuildInputs = [
+    numpy
+    colorama
+    pyfiglet
+    pygments
+    pandas
+    sqlalchemy
+    bokeh
+    plotly
+    seaborn
+    poetry-core
+  ];
+
+  pythonImportsCheck = [ "mendeleev" ];
+
+  meta = with lib; {
+    description = "Python package for accessing various properties of elements, ions and isotopes in the periodic table of elements";
+    homepage = "https://github.com/lmmentel/mendeleev";
+    license = licenses.mit;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/pyastronomy/default.nix
+++ b/pkgs/lib/pyastronomy/default.nix
@@ -1,0 +1,59 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, matplotlib
+, quantities
+, numpydoc
+, mock
+, six
+, sphinx
+, nbsphinx
+, scipy
+, bidict
+, docutils
+, ipython
+, mendeleev
+}:
+
+buildPythonPackage rec {
+  pname = "PyAstronomy";
+  version = "0.19.0";
+
+  src = with lib.versions; fetchFromGitHub {
+    owner = "sczesla";
+    repo = pname;
+    rev = "v_${major version}-${minor version}-${patch version}";
+    hash = "sha256-HFlPTvnUtfCrXV2P8kTrqpo2Ph2PoixyoCDXi+kT8ic=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    matplotlib
+    quantities
+    numpydoc
+    mock
+    six
+    sphinx
+    nbsphinx
+    scipy
+    bidict
+    docutils
+    ipython
+    mendeleev
+  ];
+
+  configureFlags = [ "--with-ext" ];
+
+  # Deprecated setuptools tests
+  doCheck = false;
+
+  pythonImportsCheck = [ "PyAstronomy" ];
+
+  meta = with lib; {
+    description = "A collection of astronomy-related routines in Python";
+    homepage = "https://github.com/sczesla/PyAstronomy";
+    license = licenses.mit;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/pymbar/default.nix
+++ b/pkgs/lib/pymbar/default.nix
@@ -1,0 +1,37 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, numpy
+, scipy
+, numexpr
+}:
+
+buildPythonPackage rec {
+  pname = "pymbar";
+  version = "4.0.2";
+
+  src = fetchFromGitHub {
+    owner = "choderalab";
+    repo = pname;
+    rev = version;
+    hash = "sha256-XNkGhEH/X5HBS92xqQHQj14JOSNkHXbLuAZ85cYhcPM=";
+  };
+
+  propagatedBuildInputs = [
+    numpy
+    scipy
+    numexpr
+  ];
+
+  # Uses deprecated pytest invocation
+  doCheck = false;
+
+  pythonImportsCheck = [ "pymbar" ];
+
+  meta = with lib; {
+    description = "Implementation of the multistate Bennett acceptance ratio";
+    homepage = "https://github.com/choderalab/pymbar";
+    license = licenses.mit;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/svgutils/default.nix
+++ b/pkgs/lib/svgutils/default.nix
@@ -1,0 +1,34 @@
+{ buildPythonPackage
+, fetchFromGitHub
+, lib
+, matplotlib
+, lxml
+, numpydoc
+, nose
+}:
+
+buildPythonPackage rec {
+  pname = "svgutils";
+  version = "0.3.4";
+
+  src = fetchFromGitHub {
+    owner = "btel";
+    repo = "svg_utils";
+    rev = "v${version}";
+    hash = "sha256-ITvZx+3HMbTyaRmCb7tR0LKqCxGjqDdV9/2taziUD0c=";
+  };
+
+  propagatedBuildInputs = [
+    matplotlib
+    lxml
+    numpydoc
+    nose
+  ];
+
+  meta = with lib; {
+    description = "Python tools to create and manipulate SVG files ";
+    homepage = "https://github.com/btel/svg_utils";
+    license = licenses.mit;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -56,6 +56,8 @@ let
 
     pyphspu = callPackage ./pkgs/lib/pyphspu { };
 
+    svgutils = callPackage ./pkgs/lib/svgutils { };
+
     veloxchem = callPackage ./pkgs/apps/veloxchem { };
 
     vermouth = callPackage ./pkgs/apps/vermouth { };

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -48,6 +48,8 @@ let
 
     psi4 = callPackage ./pkgs/apps/psi4 { };
 
+    pyastronomy = callPackage ./pkgs/lib/pyastronomy { };
+
     pychemps2 = callPackage ./pkgs/apps/chemps2/PyChemMPS2.nix { };
 
     pysisyphus = callPackage ./pkgs/apps/pysisyphus {

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -30,6 +30,8 @@ let
 
     gau2grid = callPackage ./pkgs/apps/gau2grid { };
 
+    mendeleev = callPackage ./pkgs/lib/mendeleev { };
+
     moltemplate = callPackage ./pkgs/apps/moltemplate { };
 
     optking = callPackage ./pkgs/lib/optking { };

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -30,6 +30,8 @@ let
 
     gau2grid = callPackage ./pkgs/apps/gau2grid { };
 
+    mdtraj = callPackage ./pkgs/lib/mdtraj { };
+
     mendeleev = callPackage ./pkgs/lib/mendeleev { };
 
     moltemplate = callPackage ./pkgs/apps/moltemplate { };

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -54,6 +54,8 @@ let
 
     pychemps2 = callPackage ./pkgs/apps/chemps2/PyChemMPS2.nix { };
 
+    pymbar = callPackage ./pkgs/lib/pymbar { };
+
     pysisyphus = callPackage ./pkgs/apps/pysisyphus {
       gamess-us = finalPkgs.gamess-us.override {
         enableMpi = false;


### PR DESCRIPTION
This add Poltype2, a programme from the Tinker MM developers to derive parametrisation for the polarisable AMOEBA force field. Poltype2 has the wildest setup I've seen so far and has no build tool and declares no dependencies. Instead, it uses a Conda yaml file and imports half of the universe. Among those goodies are, for example, PyAstronomy (!), just used to obtain the atomic number of atoms (!).

There is also a optional dependendency (I think) on experimental Tinker 9, which depends on the NVidia HPC SDK, which is not packaged in nixpkgs. The nvc++ compiler required by Tinker9 is absolutely non-optional for some reasons, and thus, I could not package Tinker9.

While being a terrible derivation, I really need this programme as I have to derive AMOEBA parameters for some crazy ligands. This PR is marked as draft and I will try to play around with this branch to figure out if it works as advertised. Nevertheless, feel free to review already. :)