### PR TITLE
poltype2: unset PYTHONPATH before startup

### DIFF
--- a/pkgs/apps/poltype2/default.nix
+++ b/pkgs/apps/poltype2/default.nix
@@ -37,6 +37,7 @@ buildFHSUserEnv {
   ]);
 
   profile = ''
+    unset PYTHONPATH
     eval "$(micromamba shell hook -s bash)"
     MAMBA="''${MAMBA_ROOT:-$(mktemp -d)}"
     export MAMBA_ROOT_PREFIX=$MAMBA/.mamba


### PR DESCRIPTION
Just observed the problem, that when one is in a shell with a PYTHONPATH, the PYTHONPATH from a Nix-Python environment does interfer with the Mamba Environment. For example, Poltype tries to load numpy from Nix' Python 3.10 instead of using that from its environment. By explicitly unsetting the PYTHONPATH in the profile, this is fixed. Luckily this does not influence the PYTHONPATH in the encapsulating Nix-Shell.