### PR TITLE
vmd-python: init at 3.1.2

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -302,6 +302,8 @@ let
           else callPackage ./pkgs/apps/vmd { }
         ;
 
+        vmd-python = super.python3.pkgs.toPythonApplication self.python3.pkgs.vmd-python;
+
         vossvolvox = callPackage ./pkgs/apps/vossvolvox { };
 
         wannier90 = callPackage ./pkgs/apps/wannier90 {

--- a/pkgs/apps/vmd-python/default.nix
+++ b/pkgs/apps/vmd-python/default.nix
@@ -1,0 +1,66 @@
+{ buildPythonPackage
+, lib
+, runtimeShell
+, cfg
+, fetchFromGitHub
+, netcdf
+, expat
+, sqlite
+, tcl
+, perl
+, libGLU
+, mesa
+, numpy
+, importlib-resources
+, pytest
+, enableCuda ? cfg.useCuda
+, cudaPackages
+}:
+
+buildPythonPackage rec {
+  pname = "vmd-python";
+  version = "3.1.2";
+
+  src = fetchFromGitHub {
+    owner = "Eigenstate";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-iz8Ujp+J3Wf6XQJpBylRzC2tUz9D5PMTmwTwEYAvH84=";
+  };
+
+  postPatch = ''
+    patchShebangs vmd/{install.sh,vmd_src/{configure,bin/*},plugins/create_static_headers.sh}
+
+    substituteInPlace vmd/plugins/vmdtkcon/tkcon-2.3/docs/perl.txt vmd/plugins/autoimd/namdrun.tcl vmd/vmd_src/configure \
+      --replace "/bin/sh" "${runtimeShell}"
+  '';
+
+  nativeBuildInputs = [ perl ];
+
+  buildInputs = [
+    netcdf
+    expat
+    sqlite
+    tcl
+    libGLU
+    mesa
+  ] ++ lib.optional enableCuda cudaPackages.cudatoolkit;
+
+  propagatedBuildInputs = [
+    numpy
+    importlib-resources
+  ];
+
+  preConfigure = ''
+    export LD_LIBRARY_PATH=${lib.makeLibraryPath buildInputs}
+  '';
+
+  checkInputs = [ pytest ];
+
+  meta = with lib; {
+    description = "Installable VMD as a python module";
+    homepage = "https://github.com/Eigenstate/vmd-python";
+    license = licenses.unfree;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -70,6 +70,10 @@ let
 
     vermouth = callPackage ./pkgs/apps/vermouth { };
 
+    vmd-python = callPackage ./pkgs/apps/vmd-python {
+      inherit cfg;
+    };
+
     xtb-python = callPackage ./pkgs/lib/xtb-python { };
   } // lib.optionalAttrs prev.isPy27 {
     pyquante = callPackage ./pkgs/apps/pyquante { };


### PR DESCRIPTION
Adds VMD-Python, which allows to interact with VMD via Python instead of TCL (:confounded:). VMD-Python distributes the 1.9.4 alpha sources of VMD itself and takes care of building everything.