### PR TITLE
poltype2: reduce startup time

### DIFF
--- a/pkgs/apps/poltype2/default.nix
+++ b/pkgs/apps/poltype2/default.nix
@@ -41,13 +41,16 @@ buildFHSUserEnv {
     eval "$(micromamba shell hook -s bash)"
     MAMBA="''${MAMBA_ROOT:-$(mktemp -d)}"
     export MAMBA_ROOT_PREFIX=$MAMBA/.mamba
-    if [ -f $MAMBA/environment.yml ]; then
-      chmod +w $MAMBA/environment.yml && rm $MAMBA/environment.yml
-    fi
-    cp ${src}/Environments/environment.yml $MAMBA/.
+    ENVIRONMENTFILE=$(mktemp --suffix=.yml)
+    cp ${src}/Environments/environment.yml $ENVIRONMENTFILE
     export GDMADIR=${gdma}/bin
     export PSI_SCRATCH="''${PSI_TMP:-$(mktemp -d)}"
-    micromamba env create --yes -f $MAMBA/environment.yml
+    # Create conda environment only if not yet in existence
+    {
+      micromamba env list |& grep "$MAMBA_ROOT_PREFIX/envs/amoebamdpoltype" &> /dev/null
+    } || {
+      micromamba env create --yes -f $ENVIRONMENTFILE
+    }
   '';
 
   runScript = "micromamba run -n amoebamdpoltype python ${src}/PoltypeModules/poltype.py";


### PR DESCRIPTION
This further cleans up the poltype package. Before, the mamba environment would be recreated upon each invocation. This improved versions avoids this and instead checks if the mamba environment for poltype has already been initialised. This reduces the startup beyond the first from >1min to subsecond time. Furthermore, the environment.yml file is not copied to the work directory anymore, but to a temp file.