### PR TITLE
psi4: split output -> out, dev; remove samples and test from output

### DIFF
--- a/pkgs/apps/psi4/default.nix
+++ b/pkgs/apps/psi4/default.nix
@@ -241,6 +241,8 @@ buildPythonPackage rec {
     "-DCMAKE_PREFIX_PATH=\"${gau2grid};${libxc};${qcelemental};${pcmsolver_};${dkh_};${libefp};${chemps2_};${libecpint};${cppe};${adcc}\""
   ];
 
+  outputs = [ "out" "dev" ];
+
   format = "other";
   enableParallelBuilding = true;
 
@@ -251,6 +253,12 @@ buildPythonPackage rec {
     cd build
 
     runHook postConfigure
+  '';
+
+  postInstall = ''
+    # This contains a lot of files that not needed to run the program
+    rm -r $out/share/psi4/samples
+    rm -r $out/lib/psi4/tests/
   '';
 
   postFixup =


### PR DESCRIPTION
reduced output size 424M -> 363M