### PR TITLE
poltype2: optional gaussian support

### DIFF
--- a/pkgs/apps/gaussian/default.nix
+++ b/pkgs/apps/gaussian/default.nix
@@ -1,7 +1,12 @@
-{ lib, stdenv, buildFHSUserEnv, symlinkJoin, optpath } :
+{ lib
+, stdenv
+, buildFHSUserEnv
+, symlinkJoin
+, optpath
+, version ? "16b01"
+}:
 
 let
-  version = "16b01";
   g16root = "${optpath}/gaussian/g${version}";
 
   buildEnv = exe: buildFHSUserEnv {
@@ -12,7 +17,6 @@ let
     runScript = "${g16root}/${exe}";
 
     profile = ''
-      export GAUSS_EXEDIR=${g16root}/g${version}/
       export GAUSS_SCRDIR=$TMPDIR
       export g16root=${optpath}/gaussian
       source ${g16root}/bsd/g16.profile
@@ -22,7 +26,8 @@ let
   executables = [ "g16" "formchk" "freqchk" "cubegen" "trajgen" "unfchk" "rwfdump" ];
 
 
-in symlinkJoin {
+in
+symlinkJoin {
   name = "gaussian-${version}";
   paths = map buildEnv executables;
   meta = with lib; {

--- a/pkgs/apps/poltype2/default.nix
+++ b/pkgs/apps/poltype2/default.nix
@@ -1,12 +1,11 @@
-{ micromamba
-, lib
+{ lib
 , fetchFromGitHub
 , buildFHSUserEnv
-  # Runtime executable dependencies
-, perl
-, tinker
 , gdma
+, tinker
 , autodock-vina
+, enableGaussian ? false
+, gaussian
 }:
 
 let
@@ -27,11 +26,13 @@ buildFHSUserEnv {
   targetPkgs = pkgs: (with pkgs; [
     micromamba
     bashInteractive
+    perl
+    tcsh
+  ]) ++ [
     tinker
     gdma
     autodock-vina
-    perl
-  ]);
+  ] ++ lib.optional enableGaussian gaussian;
 
   profile = ''
     # Mamba preparation
@@ -43,6 +44,10 @@ buildFHSUserEnv {
     # Configure programmes not managed by Conda
     export GDMADIR=${gdma}/bin
     export PSI_SCRATCH="''${PSI_TMP:-$(mktemp -d)}"
+
+    ${lib.strings.optionalString enableGaussian ''
+    export GAUSS_SCRDIR="''${GAUSS_TMP:-$(mktemp -d)}"
+    ''}
 
     # Setup "amoebamdpoltype" environment
     ENVIRONMENTFILE=$(mktemp --suffix=.yml)


### PR DESCRIPTION
Poltype will carry out optimisations with PCM in case a zwitterionic species is to be parametrised. With the default Psi4 driver this quickly becomes a desaster, as Psi4 does not have analytical gradients for any method with PCM. Thus, I've enabled optional Gaussian support for Poltype here.

I've also made a minor tweak to Gaussian. The version is now adjustable and I've removed `GAUSS_EXEDIR`, which is set anyway when sourcing the profile.
I would be in favour of making the default `version ? 16` to have it compliant with what the Gaussian manual expect, but this would be a backwards incompatible change without a very minor override. What do you think?