### PR TITLE
CUDA support: turn on CUDA support in nixpkgs via supportCuda

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,9 +9,15 @@ let
     else
       (import ./cfg.nix) { allowEnv = true; }; # if no config is given allow env
 
+  # Turn on CUDA in nixpkgs based on qchem settings
+  config = prev.config // {
+    cudaSupport = if cfg ? useCuda then cfg.useCuda else false;
+  };
+
   pkgs = nixpkgs {
     overlays = [ (import ./overlay.nix) ];
-    inherit (prev) config system;
+    inherit (prev) system;
+    inherit config;
   };
 
 in

--- a/release.nix
+++ b/release.nix
@@ -50,6 +50,8 @@ let
 
         checkMetaRecursively = false;
         checkMeta = true;
+
+        cudaSupport = if cfg ? useCuda then cfg.useCuda else false;
       };
     };
 


### PR DESCRIPTION
This is much easier than dealing with a seperate overlay.

CUDA support flags have been unified in https://github.com/NixOS/nixpkgs/pull/224068, so we can just use it.

