### PR TITLE
sgroup: init at 1.0, add as exciting addon

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -252,6 +252,8 @@ let
 
         scalapackfx = callPackage ./pkgs/lib/scalapackfx { };
 
+        sgroup = callPackage ./pkgs/apps/sgroup { };
+
         # blank version
         sharc = callPackage ./pkgs/apps/sharc/default.nix {
           hdf4 = super.hdf4.override {

--- a/pkgs/apps/exciting/default.nix
+++ b/pkgs/apps/exciting/default.nix
@@ -1,6 +1,17 @@
-{ lib, stdenv, fetchFromGitHub
-, gfortran, perl, libxslt, runtimeShell
-, blas, lapack, mpi, arpack }:
+{ lib
+, stdenv
+, fetchFromGitHub
+, gfortran
+, perl
+, libxslt
+, runtimeShell
+, blas
+, lapack
+, mpi
+, arpack
+, enableSgroup ? false
+, sgroup
+}:
 
 stdenv.mkDerivation rec {
   pname = "exciting";
@@ -63,6 +74,7 @@ stdenv.mkDerivation rec {
     mpi
     arpack
   ];
+  propagatedUserEnvPkgs = lib.optional enableSgroup [ sgroup ];
 
   installPhase = ''
     mkdir -p $out/bin $out/share/exciting/species

--- a/pkgs/apps/sgroup/default.nix
+++ b/pkgs/apps/sgroup/default.nix
@@ -1,0 +1,44 @@
+{ stdenv
+, fetchurl
+, lib
+}:
+
+stdenv.mkDerivation rec {
+  pname = "sgroup";
+  version = "1.0";
+
+  src = fetchurl {
+    url = "https://elsevier.digitalcommonsdata.com/public-files/datasets/xp76bp3zxs/files/c315c05e-6734-43c1-9205-76b98281c043/file_downloaded";
+    hash = "sha256-TNaoRQAFjjOmZCq7ZvQYGfxseEzo6mAwWim6HeS+Xig=";
+  };
+
+  unpackPhase = ''
+    runHook preUnpack
+
+    tar -xvf ${src}
+    cd SpaceGroups
+
+    runHook postUnpack
+  '';
+
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "LDFLAGS = -L/usr/lib" "LDFLAGS =" \
+      --replace "#FOPT    = -O3 -malign-double -malign-loops=4 -malign-jumps=4" "FOPT    = -O3 -malign-double -malign-loops=4 -malign-jumps=4"
+  '';
+
+  dontConfigure = true;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp sgroup $out/bin
+  '';
+
+  meta = with lib; {
+    description = "Determination of the space group and unit cell for a periodic solid";
+    homepage = "https://elsevier.digitalcommonsdata.com/datasets/xp76bp3zxs/1";
+    license = licenses.unfree;
+    maintainers = [ maintainers.sheepforce ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
This PR provides the sgroup utility, used by exciting to determine symmetries. Being a download link from the SI of an Elsevier paper is an interesting step in software distribution ... :)

@mathunje please let me know if it works as expected before we merge it.