### PR TITLE
sharc: split outputs, split binaries and wrappers.

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -254,12 +254,15 @@ let
 
         sgroup = callPackage ./pkgs/apps/sgroup { };
 
-        # blank version
-        sharc = callPackage ./pkgs/apps/sharc/default.nix {
+        sharc-unwrapped = callPackage ./pkgs/apps/sharc/unwrapped.nix {
           hdf4 = super.hdf4.override {
             fortranSupport = true;
             szipSupport = true;
           };
+        };
+
+        # blank version
+        sharc = callPackage ./pkgs/apps/sharc/default.nix {
           bagel = self.bagel-serial;
           molpro = self.molpro12; # V2 only compatible with versions up to 2012
           gaussian = if cfg.optpath != null then self.gaussian else null;

--- a/pkgs/apps/sharc/default.nix
+++ b/pkgs/apps/sharc/default.nix
@@ -1,20 +1,7 @@
 { stdenv
 , lib
-, fetchFromGitHub
+, sharc-unwrapped
 , makeWrapper
-, which
-, gfortran
-, blas
-, lapack
-, fftw
-, python3
-, gnuplot
-, wfoverlap
-, enablePysharc ? true
-, hdf5
-, hdf4 # HDF4 would need Fortran support in nixpkgs
-, netcdf
-, libjpeg
 , enableMolcas ? false
 , molcas
 , enableBagel ? false
@@ -29,130 +16,39 @@
 , molpro
 }:
 
-let
-  version = "3.0.1";
-  python = python3.withPackages (p: with p; [
-    numpy
-    openbabel-bindings
-    setuptools
-  ]);
-
-in
 stdenv.mkDerivation {
-  pname = "sharc";
-  inherit version;
+  inherit (sharc-unwrapped) pname version meta;
 
-  src = fetchFromGitHub {
-    owner = "sharc-md";
-    repo = "sharc";
-    rev = "v${version}";
-    hash = "sha256-aTFrLrp2PTZXvMI4UkXw/hAv225rADwo9W+k09td52U=";
-  };
+  dontUnpack = true;
 
-  outputs = [ "out" "doc" "tests" ];
-
-  nativeBuildInputs = [ makeWrapper which gfortran ];
-  buildInputs = [ blas lapack fftw python ]
-    ++ lib.optionals enablePysharc ([ libjpeg hdf5 libjpeg netcdf ] ++ hdf4.all);
-
-  patches = [
-    # Molpro tests require more memory
-    ./molpro_tests.patch
-  ];
-
-  postPatch = ''
-    # SHARC make file (dynamics fixes)
-    sed -i 's:^EXEDIR.*=.*:EXEDIR = ''${out}/bin:' source/Makefile;
-
-    # purify output
-    substituteInPlace source/Makefile --replace 'shell date' "shell echo $SOURCE_DATE_EPOCH" \
-                                      --replace 'shell hostname' 'shell echo nixos' \
-                                      --replace 'shell pwd' 'shell echo nixos' \
-                                      --replace '-ldf' '-lhdf'
-
-    rm bin/*.x
-
-    patchShebangs wfoverlap/scripts
-  '';
-
-  configurePhase = lib.optionalString enablePysharc ''
-    runHook preConfigure
-
-    substituteInPlace source/Makefile --replace 'USE_PYSHARC := false' 'USE_PYSHARC := true'
-
-    runHook postConfigure
-  '';
-
-  enableParallelBuilding = true;
+  nativeBuildInputs = [ makeWrapper ];
 
   installPhase = ''
     runHook preInstall
 
     mkdir -p $out/bin
 
-    ${lib.optionalString enablePysharc ''
-      cd pysharc
-      make
-      make install
-      cd ..
-    ''
-    }
-
-    cd source
-    make install
-    cd ..
-
-    cp -u bin/* $out/bin
-    cp wfoverlap/scripts/* $out/bin
-    cp ${wfoverlap}/bin/wfoverlap.x $out/bin/wfoverlap_ascii.x
-
-    mkdir -p $out/${python3.sitePackages}
-    cp -r lib/* $out/${python3.sitePackages}/.
-
-    mkdir -p $doc/share/sharc/tests
-    cp doc/* $doc/share/sharc
-
-    mkdir -p $tests/share/sharc/tests
-    cp -r tests/* $tests/share/sharc/tests
-
-    chmod +x $out/bin/*
-
-    for i in $(find $out/bin -type f); do
-      wrapProgram $i \
+    for i in $(find ${lib.getBin sharc-unwrapped}/bin -type f); do
+      local_name="$out/bin/$(basename $i)"
+      ln -s $i $local_name
+      wrapProgram $local_name \
         --set SHARC $out/bin \
         --set LD_LIBRARY_PATH "$LD_LIBRARY_PATH" \
         --set HOSTNAME localhost \
-        --prefix PYTHONPATH : "$out/${python3.sitePackages}" \
-        ${lib.optionalString enableMolcas "--set-default MOLCAS ${molcas}"} \
-        ${lib.optionalString enableBagel "--set-default BAGEL ${bagel}"} \
-        ${lib.optionalString enableMolpro "--set-default MOLPRO ${molpro}/bin"} \
-        ${lib.optionalString enableOrca "--set-default ORCADIR ${orca}/bin"} \
-        ${lib.optionalString enableTurbomole "--set-default TURBOMOLE ${turbomole}/bin"} \
-        ${lib.optionalString enableGaussian "--set-default GAUSSIAN ${gaussian}/bin"}
+        --prefix PYTHONPATH : "${lib.getBin sharc-unwrapped}/${sharc-unwrapped.python.sitePackages}" \
+        ${lib.optionalString enableMolcas "--set-default MOLCAS ${lib.getBin molcas}"} \
+        ${lib.optionalString enableBagel "--set-default BAGEL ${lib.getBin bagel}"} \
+        ${lib.optionalString enableMolpro "--set-default MOLPRO ${lib.getBin molpro}/bin"} \
+        ${lib.optionalString enableOrca "--set-default ORCADIR ${lib.getBin orca}/bin"} \
+        ${lib.optionalString enableTurbomole "--set-default TURBOMOLE ${lib.getBin turbomole}/bin"} \
+        ${lib.optionalString enableGaussian "--set-default GAUSSIAN ${lib.getBin gaussian}/bin"}
     done
 
-    runHook preInstall
-  '';
-
-  postFixup = ''
-    for i in $(find $out/share -name run.sh); do
-      # shebang is broken (missing !)
-      echo "fixing $i"
-      sed -i '1s:.*:#!${stdenv.shell}:' $i
-      sed -i "s:\$SHARC:$out/bin:" $i
-      sed -i 's/cd \$COPY_DIR/cd $COPY_DIR\;chmod -R +w \*/' $i
-    done
+    runHook postInstall
   '';
 
   setupHooks = [
     ./sharcHook.sh
   ];
 
-  meta = with lib; {
-    description = "Molecular dynamics (MD) program suite for excited states";
-    homepage = "https://www.sharc-md.org";
-    license = licenses.gpl3;
-    maintainers = [ maintainers.markuskowa ];
-    platforms = platforms.linux;
-  };
 }

--- a/pkgs/apps/sharc/default.nix
+++ b/pkgs/apps/sharc/default.nix
@@ -49,6 +49,8 @@ stdenv.mkDerivation {
     hash = "sha256-aTFrLrp2PTZXvMI4UkXw/hAv225rADwo9W+k09td52U=";
   };
 
+  outputs = [ "out" "doc" "tests" ];
+
   nativeBuildInputs = [ makeWrapper which gfortran ];
   buildInputs = [ blas lapack fftw python ]
     ++ lib.optionals enablePysharc ([ libjpeg hdf5 libjpeg netcdf ] ++ hdf4.all);
@@ -86,7 +88,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    mkdir -p $out/bin $out/share/sharc/tests
+    mkdir -p $out/bin
 
     ${lib.optionalString enablePysharc ''
       cd pysharc
@@ -107,12 +109,13 @@ stdenv.mkDerivation {
     mkdir -p $out/${python3.sitePackages}
     cp -r lib/* $out/${python3.sitePackages}/.
 
-    cp doc/* $out/share/sharc
-    cp -r tests/* $out/share/sharc/tests
+    mkdir -p $doc/share/sharc/tests
+    cp doc/* $doc/share/sharc
+
+    mkdir -p $tests/share/sharc/tests
+    cp -r tests/* $tests/share/sharc/tests
 
     chmod +x $out/bin/*
-
-    ln -s $out/share/sharc/tests $out/tests
 
     for i in $(find $out/bin -type f); do
       wrapProgram $i \

--- a/pkgs/apps/sharc/unwrapped.nix
+++ b/pkgs/apps/sharc/unwrapped.nix
@@ -1,0 +1,130 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, makeWrapper
+, which
+, gfortran
+, blas
+, lapack
+, fftw
+, python3
+, gnuplot
+, wfoverlap
+, enablePysharc ? true
+, hdf5
+, hdf4 # HDF4 would need Fortran support in nixpkgs
+, netcdf
+, libjpeg
+}:
+
+let
+  version = "3.0.1";
+  python = python3.withPackages (p: with p; [
+    numpy
+    openbabel-bindings
+    setuptools
+  ]);
+
+in stdenv.mkDerivation {
+  pname = "sharc";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "sharc-md";
+    repo = "sharc";
+    rev = "v${version}";
+    hash = "sha256-aTFrLrp2PTZXvMI4UkXw/hAv225rADwo9W+k09td52U=";
+  };
+
+  outputs = [ "out" "doc" "tests" ];
+
+  passthru = { inherit python; };
+
+  nativeBuildInputs = [ which gfortran ];
+  buildInputs = [ blas lapack fftw python ]
+    ++ lib.optionals enablePysharc ([ libjpeg hdf5 libjpeg netcdf ] ++ hdf4.all);
+
+  patches = [
+    # Molpro tests require more memory
+    ./molpro_tests.patch
+  ];
+
+  postPatch = ''
+    # SHARC make file (dynamics fixes)
+    sed -i 's:^EXEDIR.*=.*:EXEDIR = ''${out}/bin:' source/Makefile;
+
+    # purify output
+    substituteInPlace source/Makefile --replace 'shell date' "shell echo $SOURCE_DATE_EPOCH" \
+                                      --replace 'shell hostname' 'shell echo nixos' \
+                                      --replace 'shell pwd' 'shell echo nixos' \
+                                      --replace '-ldf' '-lhdf'
+
+    rm bin/*.x
+
+    patchShebangs wfoverlap/scripts
+  '';
+
+  configurePhase = lib.optionalString enablePysharc ''
+    runHook preConfigure
+
+    substituteInPlace source/Makefile --replace 'USE_PYSHARC := false' 'USE_PYSHARC := true'
+
+    runHook postConfigure
+  '';
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+
+    ${lib.optionalString enablePysharc ''
+      cd pysharc
+      make
+      make install
+      cd ..
+    ''
+    }
+
+    cd source
+    make install
+    cd ..
+
+    cp -u bin/* $out/bin
+    cp wfoverlap/scripts/* $out/bin
+    cp ${wfoverlap}/bin/wfoverlap.x $out/bin/wfoverlap_ascii.x
+
+    mkdir -p $out/${python3.sitePackages}
+    cp -r lib/* $out/${python3.sitePackages}/.
+
+    mkdir -p $doc/share/sharc/tests
+    cp doc/* $doc/share/sharc
+
+    mkdir -p $tests/share/sharc/tests
+    cp -r tests/* $tests/share/sharc/tests
+
+    chmod +x $out/bin/*
+
+
+    runHook preInstall
+  '';
+
+  postFixup = ''
+    for i in $(find $out/share -name run.sh); do
+      # shebang is broken (missing !)
+      echo "fixing $i"
+      sed -i '1s:.*:#!${stdenv.shell}:' $i
+      sed -i "s:\$SHARC:$out/bin:" $i
+      sed -i 's/cd \$COPY_DIR/cd $COPY_DIR\;chmod -R +w \*/' $i
+    done
+  '';
+
+  meta = with lib; {
+    description = "Molecular dynamics (MD) program suite for excited states";
+    homepage = "https://www.sharc-md.org";
+    license = licenses.gpl3;
+    maintainers = [ maintainers.markuskowa ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Optimize for cache space and build time:

* split up into sharc-unwrapped and the actual wrappers.
  This saves a lot of space and some build time. We need to build the SHARC binaries only once.
  Space saving: N * 5 MB vs. 5 MB + N * 0.5 MB

* use separate outputs for the documentation and the tests. Save space in run time closure.
  binaries (5 MB), manual (7.5 MB), tests (30 MB).

Overall savings with both changes: N * 43 MB vs. 5 MB + 30 MB + 7.5 MB + N * 0.5 MB