### PR TITLE
exciting: propagate MPI

### DIFF
--- a/pkgs/apps/exciting/default.nix
+++ b/pkgs/apps/exciting/default.nix
@@ -74,7 +74,10 @@ stdenv.mkDerivation rec {
     mpi
     arpack
   ];
-  propagatedUserEnvPkgs = lib.optional enableSgroup [ sgroup ];
+
+  propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ] ++ lib.optional enableSgroup sgroup;
+  passthru = { inherit mpi; };
 
   installPhase = ''
     mkdir -p $out/bin $out/share/exciting/species

--- a/pkgs/apps/exciting/default.nix
+++ b/pkgs/apps/exciting/default.nix
@@ -71,7 +71,6 @@ stdenv.mkDerivation rec {
   buildInputs = [
     blas
     lapack
-    mpi
     arpack
   ];
 


### PR DESCRIPTION
Exciting is missing the propagation of MPI for runtime usage. Has been added.