### PR TITLE
psi4: do not split output

### DIFF
--- a/pkgs/apps/psi4/default.nix
+++ b/pkgs/apps/psi4/default.nix
@@ -241,8 +241,6 @@ buildPythonPackage rec {
     "-DCMAKE_PREFIX_PATH=\"${gau2grid};${libxc};${qcelemental};${pcmsolver_};${dkh_};${libefp};${chemps2_};${libecpint};${cppe};${adcc}\""
   ];
 
-  outputs = [ "out" "dev" ];
-
   format = "other";
   enableParallelBuilding = true;
 


### PR DESCRIPTION
The breakage was introduced here: 035b0a7f0dae374c29734a9847dd397b43f15f8e

closes https://github.com/Nix-QChem/NixOS-QChem/issues/379

Using split outputs with dev breaks the python run time env, when trying to run the psi4 program directly without a nix-shell.