### PR TITLE
mendeleev: relax dependency requirement for pyfiglet

### DIFF
--- a/pkgs/lib/mendeleev/default.nix
+++ b/pkgs/lib/mendeleev/default.nix
@@ -1,6 +1,7 @@
 { buildPythonPackage
 , fetchFromGitHub
 , lib
+, pythonRelaxDepsHook
 , numpy
 , colorama
 , pyfiglet
@@ -37,6 +38,13 @@ buildPythonPackage rec {
     plotly
     seaborn
     poetry-core
+  ];
+
+  nativeBuildInputs = [
+    pythonRelaxDepsHook
+  ];
+  pythonRelaxDeps = [
+    "pyfiglet"
   ];
 
   pythonImportsCheck = [ "mendeleev" ];


### PR DESCRIPTION
unbreak build, see https://github.com/Nix-QChem/NixOS-QChem/pull/387 and https://github.com/Nix-QChem/NixOS-QChem/issues/388