### PR TITLE
tests.molcas: port test input to modern syntax

### DIFF
--- a/tests/molcas/molcas.inp
+++ b/tests/molcas/molcas.inp
@@ -1,56 +1,45 @@
-&GATEWAY
-Coord
-4
-MCSCF/6-311G*//MCSCF/6-311G* Energy:   -113.980429893663
-C          0.0000000029        0.0000000000        0.0578695492 Angstrom
-O         -0.0000000045        0.0000000000        1.2773690285 Angstrom
-H          0.9290327294        0.0000000000       -0.5121192921 Angstrom
-H         -0.9290327279        0.0000000000       -0.5121192856 Angstrom
-GROUP
-NOSYM
-BASIS
-cc-pVQZ
+&gateway
+  Coord
+    4
+    Methanal
+    C          0.0000000029        0.0000000000        0.0578695492 Angstrom
+    O         -0.0000000045        0.0000000000        1.2773690285 Angstrom
+    H          0.9290327294        0.0000000000       -0.5121192921 Angstrom
+    H         -0.9290327279        0.0000000000       -0.5121192856 Angstrom
+  group = nosym
+  basis = cc-pVQZ
 
-&SEWARD
+&seward
 
-&SCF
+&scf
 
-&RASSCF
-LUMORB
-Title
-CAS
-Spin
-1
-Symmetry
-1
-nActEl
-4
-Inactive
-6
-Ras2
-3
-CIRO
-3 3 1
+&rasscf
+  lumorb
+  title = CAS
+  spin = 1
+  symmetry = 1
+  nactel = 4
+  inactive = 6
+  ras2 = 3
+  ciroot = 3 3 1
 
 
-&CASPT2
-Multistate
-3 1 2 3
+&caspt2
+  multistate = 3 1 2 3
 
-&MOTRA
-JobIph
+&motra
+  JobIph
 
-&GUGA
-Electrons= 16; Spin= 1
-Inactive= 6; Active= 3;
-CIAll= 1
+&guga
+  electrons= 16
+  spin= 1
+  inactive= 6
+  active= 3;
+  ciall= 1
 
-&MRCI
-SDCI
-NRRoots
-2
-Root
-1 2
-MAXI
-35
+&mrci
+  sdci
+  nrroots = 2
+  root = 1 2
+  maxi = 35
 


### PR DESCRIPTION
See #388 

New versions of pymolcas and pyparsing were thinking that the comment line in the coord section in Molcas' input would be a regular expression. I don't see any reasonable way to fix how Molcas is using pyparsing and as pyparsing decided to stop parsing out input file, I've decided to take the chance to port the input file over to the modern molcas syntax. This then also fixes the test. I guess the old input is simply not compatible with new molcas versions.