### PR TITLE
Crest updates

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -170,6 +170,8 @@ let
 
         gfn0 = callPackage ./pkgs/apps/gfn0 { };
 
+        gfnff = callPackage ./pkgs/apps/gfnff { };
+
         iboview = prev.libsForQt5.callPackage ./pkgs/apps/iboview { };
 
         janpa = callPackage ./pkgs/apps/janpa { };

--- a/overlay.nix
+++ b/overlay.nix
@@ -168,6 +168,8 @@ let
 
         gdma = callPackage ./pkgs/apps/gdma { };
 
+        gfn0 = callPackage ./pkgs/apps/gfn0 { };
+
         iboview = prev.libsForQt5.callPackage ./pkgs/apps/iboview { };
 
         janpa = callPackage ./pkgs/apps/janpa { };

--- a/pkgs/apps/crest/default.nix
+++ b/pkgs/apps/crest/default.nix
@@ -1,45 +1,53 @@
 { stdenv
 , lib
-, fetchpatch
-, makeWrapper
 , cmake
 , gfortran
 , blas
 , lapack
 , fetchFromGitHub
-, xtb
-, xtb-iff
+, tblite
+, mctc-lib
+, toml-f
+, simple-dftd3
+, dftd4
+, multicharge
+, gfn0
+, gfnff
 }:
 
 stdenv.mkDerivation rec {
   pname = "crest";
-  version = "2.12";
+  version = "unstable-2024-02-14";
 
   src = fetchFromGitHub {
     owner = "grimme-lab";
     repo = pname;
-    rev = "v${version}";
-    hash = "sha256-pTOcwKvAX9N2TQhfV9jJhik+0vLQB3MhHzR2fU4+oV0=";
+    rev = "72dcc2d92f933424babb4905a3712559eb74915d";
+    hash = "sha256-Ck38VZBTvbwcVbOOlU1sjzcBmk+NciVsKtG2fPeYeZA=";
   };
+
+  postPatch = ''
+    chmod -R +rwx ./subprojects
+    cp -r ${gfnff.src}/* subprojects/gfnff/.
+    cp -r ${gfn0.src}/* subprojects/gfn0/.
+    chmod -R +rwx ./subprojects
+  '';
 
   nativeBuildInputs = [
     cmake
-    makeWrapper
     gfortran
   ];
 
-  buildInputs = [ blas lapack ];
-
-  FFLAGS = "-ffree-line-length-512";
-
-  hardeningDisable = [ "all" ];
-
-  postFixup = ''
-    wrapProgram $out/bin/crest \
-      --prefix PATH : "${xtb}/bin" \
-      --prefix PATH : "${xtb-iff}/bin" \
-      --set-default XTBPATH ${xtb}/share/xtb
-  '';
+  buildInputs = [
+    tblite
+    mctc-lib
+    toml-f
+    simple-dftd3
+    dftd4
+    multicharge
+    blas
+    lapack
+  ];
 
   meta = with lib; {
     description = "Conformer-Rotamer Ensemble Sampling Tool based on the xtb Semiempirical Extended Tight-Binding Program Package";

--- a/pkgs/apps/gfn0/default.nix
+++ b/pkgs/apps/gfn0/default.nix
@@ -1,0 +1,43 @@
+{ stdenv
+, lib
+, cmake
+, gfortran
+, fetchFromGitHub
+, blas
+, lapack
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gfn0";
+  version = "unstable-2023-07-22";
+
+  src = fetchFromGitHub {
+    owner = "pprcht";
+    repo = pname;
+    rev = "b0d68ec6b44a176db6c3684d7ccc9776e9a50394";
+    hash = "sha256-257XGz5ZosPnbWjTgM2Bt7hH09ZQkTaW5Vu7udMSIhI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/${pname}/${pname}-*.cmake \
+      --replace "libgfn0.a" "libgfn0.${stdenv.hostPlatform.extensions.library}"
+  '';
+
+  meta = with lib; {
+    description = "Standalone implementation of the GFN0-xTB method";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    homepage = "https://github.com/pprcht/gfn0";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/apps/gfnff/default.nix
+++ b/pkgs/apps/gfnff/default.nix
@@ -1,0 +1,47 @@
+{ stdenv
+, lib
+, cmake
+, gfortran
+, fetchFromGitHub
+, blas
+, lapack
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gfnff";
+  version = "unstable-2024-02-14";
+
+  src = fetchFromGitHub {
+    owner = "pprcht";
+    repo = pname;
+    rev = "4d68ac1ab8df5999d3493715a86c13786bac6bfb";
+    hash = "sha256-K1KwfrMqnXi1Mj3PDGYgHdG9WLuXFtrNqtfeL5wkDtI=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+  ];
+
+  cmakeFlags = [
+    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  ];
+
+  postInstall = ''
+    substituteInPlace $out/lib/cmake/${pname}/${pname}-*.cmake \
+      --replace "libgfnff.a" "libgfnff.${stdenv.hostPlatform.extensions.library}"
+  '';
+
+  meta = with lib; {
+    description = "A standalone library of the GFN-FF method. Extracted in large parts from the xtb program";
+    license = with licenses; [ gpl3Only lgpl3Only ];
+    homepage = "https://github.com/pprcht/gfnff";
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
Updates crest to current head of the main branch. This is mainly intended to mitigate https://github.com/crest-lab/crest/issues/216 (breaking QCG with gfortran). The current solution fake-initialises gfn0 and gfnff as submodules as they can not be found by CMake as external packages for some reasons.