### PR TITLE
github/nix-checks: checkout v3 -> v4

### DIFF
--- a/.github/workflows/editorconfig.yml
+++ b/.github/workflows/editorconfig.yml
@@ -6,11 +6,11 @@ jobs:
     name: Editor config check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get changed files
       id: changed-files
       uses: tj-actions/changed-files@v41
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v25
     - run: |
         for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
           nix run nixpkgs#editorconfig-checker -- $file

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -6,7 +6,7 @@ jobs:
     name: nix-instantiate
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
     name: nix flake check
     runs-on: ubuntu-latest
     steps:
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v25
       - uses: actions/checkout@v4
       - run: nix flake check --accept-flake-config --no-build
 
@@ -25,7 +25,7 @@ jobs:
     name: statix code check
     runs-on: ubuntu-latest
     steps:
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v25
     - uses: actions/checkout@v4
     - name: get changed files
       id: changed-files

--- a/.github/workflows/nix-checks.yml
+++ b/.github/workflows/nix-checks.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: cachix/install-nix-action@v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: nix-instantiate release.nix -A qchem
 
   # Check if the flake is sane
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: cachix/install-nix-action@v20
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: nix flake check --accept-flake-config --no-build
 
   statix:
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: cachix/install-nix-action@v20
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: get changed files
       id: changed-files
       uses: tj-actions/changed-files@v41

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install Nix on the runner
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       # Pull from the cachix cache
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install Nix on the runner
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Magic Nix Cache
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install Nix on the runner
-      - uses: cachix/install-nix-action@v20
+      - uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Magic Nix Cache

--- a/.github/workflows/nix-rebuild.yml
+++ b/.github/workflows/nix-rebuild.yml
@@ -16,15 +16,15 @@ jobs:
         with:
           name: nix-qchem
       # Checkout of the current head in the working dir
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Get PR target branch checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           repository: ${{ github.event.pull_request.base.repo.full_name }}
           path: pr_base
       # Get a checkout of this PR
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -55,7 +55,7 @@ jobs:
         with:
           name: nix-qchem
       # Checkout of the current head in the working dir
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       # Get changed derivations as artifact from previous step
@@ -90,7 +90,7 @@ jobs:
         with:
           name: nix-qchem
       # Checkout merge commit as if PR would already be merged
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Get changed derivations as artifact from previous step
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Updating to recommended to avoid outdated node.js version.
Update nix-install-action, fix problem with nix flake check.