### PR TITLE
vmd-python: fix mesa argument

### DIFF
--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -72,6 +72,7 @@ let
 
     vmd-python = callPackage ./pkgs/apps/vmd-python {
       inherit cfg;
+      inherit (finalPkgs.pkgs) mesa;
     };
 
     xtb-python = callPackage ./pkgs/lib/xtb-python { };


### PR DESCRIPTION
vmd-python got the python3.pkgs.mesa derivation instead of mesa the graphics API. I wonder why this has ever worked before but I think mesa the graphics driver is somewhere in the dependency tree of python3.pkgs.mesa. But whatever, fixes #388 vmd-python part.