### PR TITLE
salmon: init at 2.2.0

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -249,6 +249,8 @@ let
 
         qmcpack = callPackage ./pkgs/apps/qmcpack { };
 
+        salmon = callPackage ./pkgs/apps/salmon { };
+
         scalapackfx = callPackage ./pkgs/lib/scalapackfx { };
 
         sgroup = callPackage ./pkgs/apps/sgroup { };

--- a/pkgs/apps/salmon/cpp.patch
+++ b/pkgs/apps/salmon/cpp.patch
@@ -1,0 +1,91 @@
+diff --git a/cmakefiles/Builder/build_scalapack.cmake b/cmakefiles/Builder/build_scalapack.cmake
+index fe80d9ff..12dd9387 100644
+--- a/cmakefiles/Builder/build_scalapack.cmake
++++ b/cmakefiles/Builder/build_scalapack.cmake
+@@ -1,51 +1,2 @@
+-include(ExternalProject)
+-include(CheckLibraryExists)
+-
+-if (USE_MPI)
+-else ()
+-  message(FATAL_ERROR "Use ScaLAPACK: but MPI feature disabled.")
+-endif ()
+-
+-if (ScaLAPACK_VENDOR_FLAGS)
+-  message(STATUS "Set vendor-specific ScaLAPACK libraries: ${ScaLAPACK_VENDOR_FLAGS}")
+-  set(EXTERNAL_FLAGS ${ScaLAPACK_VENDOR_FLAGS} ${EXTERNAL_FLAGS})
+-elseif (LAPACK_VENDOR_FLAGS)
+-  message(FATAL_ERROR "Set vendor-specific LAPACK libraries: ${LAPACK_VENDOR_FLAGS}, however, ScaLAPACK will ignore it.")
+-else ()
+-  # NOTE: ScaLAPACK with CMake will builds LAPACK libraries as necessary.
+-  find_package(ScaLAPACK QUIET)
+-
+-  if (ScaLAPACK_FOUND)
+-    message(STATUS "ScaLAPACK library found.")
+-    set(EXTERNAL_LIBS ${EXTERNAL_LIBS} ${ScaLAPACK_LINKER_FLAGS} ${ScaLAPACK_LIBRARIES})
+-  else ()
+-    set(SCALAPACK_VERSION "2.1.0")
+-    message(STATUS "Build Netlib ScaLAPACK library version ${SCALAPACK_VERSION}")
+-
+-    include(${CMAKE_SOURCE_DIR}/cmakefiles/Builder/build_lapack.cmake)
+-
+-    ExternalProject_Add(scalapack-project
+-      URL              "https://github.com/Reference-ScaLAPACK/scalapack/archive/v${SCALAPACK_VERSION}.tar.gz"
+-      PREFIX           "${CMAKE_BINARY_DIR}/scalapack"
+-      CMAKE_ARGS       -D BUILD_SHARED_LIBS=off -D BUILD_TESTING=off
+-                       -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -D CMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}
+-                       -D CMAKE_C_COMPILER=${CMAKE_C_COMPILER} -D CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
+-                       -D CMAKE_C_FLAGS=${CMAKE_C_FLAGS} -D CMAKE_Fortran_FLAGS=${CMAKE_Fortran_FLAGS}
+-                       -D CMAKE_C_FLAGS_DEBUG=${CMAKE_C_FLAGS_DEBUG} -D CMAKE_Fortran_FLAGS_DEBUG=${CMAKE_Fortran_FLAGS_DEBUG}
+-                       -D CMAKE_C_FLAGS_RELEASE=${CMAKE_C_FLAGS_RELEASE} -D CMAKE_Fortran_FLAGS_RELEASE=${CMAKE_Fortran_FLAGS_RELEASE}
+-      STEP_TARGETS     install
+-      EXCLUDE_FROM_ALL on
+-    )
+-
+-    if (LAPACK_FOUND)
+-    else ()
+-      add_dependencies(scalapack-project-install lapack-project-install)
+-    endif ()
+-
+-    set(SCALAPACK_LIBPATH ${CMAKE_CURRENT_BINARY_DIR}/lib/libscalapack.a)
+-    add_library(scalapack STATIC IMPORTED)
+-    set_target_properties(scalapack PROPERTIES IMPORTED_LOCATION ${SCALAPACK_LIBPATH})
+-    add_dependencies(scalapack scalapack-project-install)
+-    set(EXTERNAL_LIBS scalapack ${EXTERNAL_LIBS})
+-  endif ()
+-endif ()
++message(STATUS "ScaLAPACK library found.")
++set(EXTERNAL_LIBS ${EXTERNAL_LIBS} -lscalapack)
+diff --git a/src/common/initialization.f90 b/src/common/initialization.f90
+index 4d94f944..6dd256e6 100644
+--- a/src/common/initialization.f90
++++ b/src/common/initialization.f90
+@@ -1102,7 +1102,7 @@ subroutine prep_dgf(lg,mg,system,info,poisson)
+   if(yn_fftw=='y') then
+     call fftw_mpi_init()
+   end if
+-#ENDIF
++#endif
+ 
+   return
+ end subroutine prep_dgf
+diff --git a/src/maxwell/fdtd_eh.f90 b/src/maxwell/fdtd_eh.f90
+index aa90f9bd..1a005368 100644
+--- a/src/maxwell/fdtd_eh.f90
++++ b/src/maxwell/fdtd_eh.f90
+@@ -225,7 +225,6 @@ contains
+     implicit none
+     type(s_fdtd_system),intent(inout) :: fs
+     type(ls_fdtd_eh),   intent(inout) :: fe
+-    procedure(integer)  :: access,system
+     integer             :: istatus
+     integer             :: nsg_p          !yn_restart='y': nproc_size_global used in the previous calc.
+     integer             :: nt_em_p        !yn_restart='y': nt_em             used in the previous calc.
+@@ -3217,7 +3216,6 @@ contains
+     implicit none
+     type(s_fdtd_system),intent(inout) :: fs
+     type(ls_fdtd_eh),   intent(inout) :: fe
+-    procedure(integer) :: system
+     integer            :: istatus
+     integer            :: iter,ii,ix,iy,iz
+     integer            :: is5(5),ie5(5)

--- a/pkgs/apps/salmon/default.nix
+++ b/pkgs/apps/salmon/default.nix
@@ -1,0 +1,64 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, gfortran
+, blas
+, lapack
+, scalapack
+, fftwMpi
+, mpi
+}:
+
+stdenv.mkDerivation rec {
+  pname = "salmon";
+  version = "2.2.0";
+
+  src = fetchFromGitHub {
+    owner = "SALMON-TDDFT";
+    repo = "SALMON2";
+    rev = "v.${version}";
+    hash = "sha256-ntpylcrlFALooEjadz4DYxCnmeHa34A7LpifSc89jFo=";
+  };
+
+  patches = [
+    ./cpp.patch
+  ];
+
+  nativeBuildInputs = [
+    gfortran
+    cmake
+  ];
+
+  buildInputs = [
+    blas
+    lapack
+    scalapack
+    fftwMpi
+    gfortran.cc
+  ];
+
+  propagatedBuildInputs = [ mpi ];
+
+  preConfigure = ''
+    cmakeFlagsArray+=(
+      "-DCMAKE_Fortran_FLAGS=-fallow-argument-mismatch -I${lib.getDev fftwMpi}/include"
+      "-DCMAKE_EXE_LINKER_FLAGS=-lfftw3_mpi -lfftw3 -lgomp -lmpi -lblas -llapack -lscalapack -lgfortran"
+      "-DUSE_MPI=ON"
+      "-DUSE_FFTW=ON"
+      "-DUSE_SCALAPACK=ON"
+      "-DScaLAPACK_FOUND=ON"
+      "-DScaLAPACK_LIBRARIES=-lscalapack"
+    )
+  '';
+
+  passthru = { inherit mpi; };
+
+  meta = with lib; {
+    description = "Scalable Ab-initio Light-Matter simulator for Optics and Nanoscience";
+    homepage = "https://github.com/SALMON-TDDFT/SALMON2";
+    license = with licenses; [ asl20 ];
+    maintainers = [ maintainers.sheepforce ];
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Adds the Salmon TDDFT code https://salmon-tddft.jp/

The build system is terribly broken and I had to patch out overrides of fortran intrinsics , the entire Scalapack detection and all link libraries need to be specified manually. The upstream instructs me to call a `configure.py` wrapper around CMake, but this makes things worse. This should be the fully featured and working version with some terrible hacks around the broken CMake.