### PR TITLE
salmon: add mpi to propagatedUserEnvPackages

### DIFF
--- a/pkgs/apps/salmon/default.nix
+++ b/pkgs/apps/salmon/default.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation rec {
   ];
 
   propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ];
 
   preConfigure = ''
     cmakeFlagsArray+=(


### PR DESCRIPTION
In #413  I forgot to add mpi to the propagatedUserEnvPackages. Hereby fixed.