### PR TITLE
xtb ecosystem updates

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -133,6 +133,8 @@ let
 
         chemps2 = callPackage ./pkgs/apps/chemps2 { };
 
+        cpcm-x = callPackage ./pkgs/lib/cpcm-x { };
+
         crest = callPackage ./pkgs/apps/crest { };
 
         dalton = callPackage ./pkgs/apps/dalton { };

--- a/overlay.nix
+++ b/overlay.nix
@@ -215,6 +215,8 @@ let
 
         gmultiwfn = callPackage ./pkgs/apps/gmultiwfn { };
 
+        numsa = callPackage ./pkgs/lib/numsa { };
+
         orca = callPackage ./pkgs/apps/orca { };
 
         orient = callPackage ./pkgs/apps/orient { };

--- a/overlay.nix
+++ b/overlay.nix
@@ -324,7 +324,16 @@ let
         };
 
         xtb = callPackage ./pkgs/apps/xtb {
-          gfortran = final.gfortran11;
+          # XTB declares a tblite dependency >= 0.2.0 but actually requires > 0.3.0
+          tblite = super.tblite.overrideAttrs (old: {
+            patches = [ ];
+            src = super.fetchFromGitHub {
+              owner = "tblite";
+              repo = "tblite";
+              rev = "1bd936ca81f6f9ec9bbe65e32bc422ff5388571b";
+              hash = "sha256-ywXpnKU5CkPSp4zfJkFvrN09ptjt3tqq2zSqPcHAv6E=";
+            };
+          });
         };
 
         xtb-iff = callPackage ./pkgs/apps/xtb-iff { };

--- a/pkgs/apps/crest/build.patch
+++ b/pkgs/apps/crest/build.patch
@@ -1,0 +1,76 @@
+diff --git a/config/meson.build b/config/meson.build
+index 518ddf1..25d1bd6 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -198,7 +198,6 @@ if get_option('WITH_TBLITE')
+    'tblite',
+    version: '>=0.2',
+    fallback: ['tblite', 'tblite_dep'],
+-   default_options: ['default_library=static', 'api=false'],
+  )
+  exe_deps += tblite_dep
+ endif
+@@ -210,7 +209,6 @@ if get_option('WITH_TOMLF')
+    'toml-f',
+    version: '>=0.2.0',
+    fallback: ['toml-f', 'tomlf_dep'],
+-   default_options: ['default_library=static'],
+  )
+  exe_deps += tomlf_dep
+ endif
+@@ -222,7 +220,7 @@ if get_option('WITH_GFN0')
+    'gfn0',
+ #   version: '>=0.2',
+    fallback: ['gfn0', 'gfn0_dep'],
+-   default_options: ['default_library=static','with_gbsa=true'],
++   default_options: ['with_gbsa=true'],
+  )
+  exe_deps += gfn0_dep
+ endif
+@@ -233,7 +231,7 @@ if get_option('WITH_GFNFF')
+  gfnff_dep = dependency(
+    'gfnff',
+    fallback: ['gfnff', 'gfnff_dep'],
+-   default_options: ['default_library=static','with_gbsa=true'],
++   default_options: ['with_gbsa=true'],
+  )
+  exe_deps += gfnff_dep
+ endif
+@@ -245,7 +243,6 @@ if get_option('WITH_XHCFF')
+  xhcff_dep = dependency(
+    'xhcff',
+    fallback: ['xhcff', 'xhcfflib_dep'],
+-   default_options: ['default_library=static'],
+  )
+  exe_deps += xhcff_dep
+ endif
+@@ -257,11 +254,13 @@ if get_option('WITH_LWONIOM')
+  lwoniom_dep = dependency(
+    'lwoniom',
+    fallback: ['lwoniom', 'lwoniom_dep'],
+-   default_options: ['default_library=static'],
+  )
+  exe_deps += lwoniom_dep
+ endif
+ 
++mctc_dep = dependency('mctc-lib')
++exe_deps += mctc_dep
++
+ 
+ ## ========================================= ##
+ ## populate the data for crest_metadata.fh
+diff --git a/meson.build b/meson.build
+index 87d8876..21cdc82 100644
+--- a/meson.build
++++ b/meson.build
+@@ -22,9 +22,7 @@ project(
+   meson_version: '>=0.63',
+   default_options: [
+     'buildtype=debugoptimized',
+-    'default_library=static',
+-    'c_link_args=-static',
+-    'fortran_link_args=-static',
++    'default_library=both',
+   ],
+ )
+ install = not (meson.is_subproject() and get_option('default_library') == 'static')

--- a/pkgs/apps/crest/default.nix
+++ b/pkgs/apps/crest/default.nix
@@ -1,6 +1,9 @@
 { stdenv
 , lib
-, cmake
+, meson
+, ninja
+, pkg-config
+, hostname
 , gfortran
 , blas
 , lapack
@@ -15,27 +18,40 @@
 , gfnff
 }:
 
-stdenv.mkDerivation rec {
+let lwoniom = fetchFromGitHub {
+      owner = "crest-lab";
+      repo = "lwoniom";
+      rev = "ab66c7ebc3066328a8fc313dc783aec9b773cad2";
+      hash = "sha256-9FFlaGEHhsdS+23/7FnrteGwI9pvHb/q5A8C3iJxwnQ=";
+    };
+
+in stdenv.mkDerivation rec {
   pname = "crest";
-  version = "unstable-2024-02-14";
+  version = "unstable-2024-03-19";
 
   src = fetchFromGitHub {
     owner = "grimme-lab";
     repo = pname;
-    rev = "72dcc2d92f933424babb4905a3712559eb74915d";
-    hash = "sha256-Ck38VZBTvbwcVbOOlU1sjzcBmk+NciVsKtG2fPeYeZA=";
+    rev = "2719412edf8bb606cebdd4cd6bbb4cdbd249e1e5";
+    hash = "sha256-GakDssC4IoVUmRqKwOa6v6LWl37JUcpStUJN5huEP6c=";
   };
+
+  patches = [ ./build.patch ];
 
   postPatch = ''
     chmod -R +rwx ./subprojects
-    cp -r ${gfnff.src}/* subprojects/gfnff/.
-    cp -r ${gfn0.src}/* subprojects/gfn0/.
+    cp -r ${gfn0.src}/* ./subprojects/gfn0/.
+    cp -r ${gfnff.src}/* ./subprojects/gfnff/.
+    cp -r ${lwoniom}/* ./subprojects/lwoniom/.
     chmod -R +rwx ./subprojects
   '';
 
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
+    pkg-config
     gfortran
+    hostname
   ];
 
   buildInputs = [
@@ -48,6 +64,12 @@ stdenv.mkDerivation rec {
     blas
     lapack
   ];
+
+  mesonFlags = [
+    "-Dla_backend=netlib"
+  ];
+
+  doCheck = true;
 
   meta = with lib; {
     description = "Conformer-Rotamer Ensemble Sampling Tool based on the xtb Semiempirical Extended Tight-Binding Program Package";

--- a/pkgs/apps/dftbplus/default.nix
+++ b/pkgs/apps/dftbplus/default.nix
@@ -3,6 +3,7 @@
 , gfortran
 , fetchFromGitHub
 , cmake
+, pkg-config
 , blas
 , lapack
 , mpi
@@ -24,41 +25,35 @@ assert !blas.isILP64 && !lapack.isILP64;
 
 buildPythonPackage rec {
   pname = "dftbplus";
-  version = "22.2";
+  version = "24.1";
 
   src = fetchFromGitHub {
     owner = "dftbplus";
     repo = pname;
     rev = version;
-    hash = "sha256-bADKCee5vBH3aIhuo0Ce/GrZ//nd8j4AcWDSWYoLRY4=";
+    hash = "sha256-lI0l977SYHIgPKZ9037q7IYudAck2vyI2byW0vBB680=";
+    fetchSubmodules = true;
   };
 
   postPatch = ''
     patchShebangs .
 
     substituteInPlace tools/dptools/CMakeLists.txt \
-      --replace '$DESTDIR/' ""
+      --replace-fail '$DESTDIR/' ""
+
+
   '';
 
   nativeBuildInputs = [
     gfortran
     cmake
+    pkg-config
   ];
 
   buildInputs = [
     blas
     lapack
     scalapack
-    test-drive
-    mctc-lib
-    mstore
-    toml-f
-    tblite
-    mpifx
-    scalapackfx
-    simple-dftd3
-    multicharge
-    dftd4
   ];
 
   propagatedBuildInputs = [ numpy ];
@@ -69,8 +64,8 @@ buildPythonPackage rec {
     "-DWITH_API=ON"
     "-DWITH_OMP=ON"
     "-DWITH_MPI=ON"
-    "-DWITH_TBLITE=ON"
-    "-DWITH=SDFTD3=ON"
+    "-DWITH_TBLITE=OFF"
+    "-DWITH_SDFTD3=OFF"
     "-DWITH_PYTHON=ON"
     "-DSCALAPACK_LIBRARY=${scalapack}/lib/libscalapack.so"
   ];

--- a/pkgs/apps/gfn0/build.patch
+++ b/pkgs/apps/gfn0/build.patch
@@ -1,0 +1,27 @@
+diff --git a/meson.build b/meson.build
+index 3d80d6c..fb8de78 100644
+--- a/meson.build
++++ b/meson.build
+@@ -6,12 +6,10 @@ project(
+   meson_version: '>=0.63',
+   default_options: [
+     'buildtype=debugoptimized',
+-    'default_library=static',
+-    'c_link_args=-static',
+-    'fortran_link_args=-static',
++    'default_library=both',
+   ],
+ )
+-install = not (meson.is_subproject() and get_option('default_library') == 'static')
++install = true
+ 
+ # General configuration information
+ exe_deps = []
+@@ -32,6 +30,7 @@ gfn0_lib = library(
+   sources: srcs,
+   dependencies: exe_deps,
+   include_directories: include_directories('include'),
++  install: true,
+ )
+ 
+ # Export as dependency

--- a/pkgs/apps/gfn0/default.nix
+++ b/pkgs/apps/gfn0/default.nix
@@ -1,6 +1,8 @@
 { stdenv
 , lib
-, cmake
+, meson
+, ninja
+, pkg-config
 , gfortran
 , fetchFromGitHub
 , blas
@@ -9,17 +11,21 @@
 
 stdenv.mkDerivation rec {
   pname = "gfn0";
-  version = "unstable-2023-07-22";
+  version = "unstable-2024-03-07";
 
   src = fetchFromGitHub {
     owner = "pprcht";
     repo = pname;
-    rev = "b0d68ec6b44a176db6c3684d7ccc9776e9a50394";
-    hash = "sha256-257XGz5ZosPnbWjTgM2Bt7hH09ZQkTaW5Vu7udMSIhI=";
+    rev = "1701599ca4298ecb5c3741a9e56d67ce03e9e4c3";
+    hash = "sha256-slUShllJ3shUZaEnEIhy6QbDzteNSlbLrokPKgYhG7I=";
   };
 
+  patches = [ ./build.patch ];
+
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
+    pkg-config
     gfortran
   ];
 
@@ -28,10 +34,9 @@ stdenv.mkDerivation rec {
     lapack
   ];
 
-  postInstall = ''
-    substituteInPlace $out/lib/cmake/${pname}/${pname}-*.cmake \
-      --replace "libgfn0.a" "libgfn0.${stdenv.hostPlatform.extensions.library}"
-  '';
+  mesonFlags = [
+    "-Dla_backend=netlib"
+  ];
 
   meta = with lib; {
     description = "Standalone implementation of the GFN0-xTB method";

--- a/pkgs/apps/gfnff/build.patch
+++ b/pkgs/apps/gfnff/build.patch
@@ -1,0 +1,23 @@
+diff --git a/meson.build b/meson.build
+index f359ceb..932c098 100644
+--- a/meson.build
++++ b/meson.build
+@@ -6,9 +6,7 @@ project(
+   meson_version: '>=0.63',
+   default_options: [
+     'buildtype=debugoptimized',
+-    'default_library=static',
+-    'c_link_args=-static',
+-    'fortran_link_args=-static',
++    'default_library=both',
+   ],
+ )
+ install = not (meson.is_subproject() and get_option('default_library') == 'static')
+@@ -32,6 +30,7 @@ gfnff_lib = library(
+   sources: srcs,
+   dependencies: exe_deps,
+   include_directories: include_directories('include'),
++  install: true,
+ )
+ 
+ # Export as dependency

--- a/pkgs/apps/gfnff/default.nix
+++ b/pkgs/apps/gfnff/default.nix
@@ -1,6 +1,8 @@
 { stdenv
 , lib
-, cmake
+, meson
+, ninja
+, pkg-config
 , gfortran
 , fetchFromGitHub
 , blas
@@ -18,8 +20,12 @@ stdenv.mkDerivation rec {
     hash = "sha256-K1KwfrMqnXi1Mj3PDGYgHdG9WLuXFtrNqtfeL5wkDtI=";
   };
 
+  patches = [ ./build.patch ];
+
   nativeBuildInputs = [
-    cmake
+    meson
+    ninja
+    pkg-config
     gfortran
   ];
 
@@ -28,14 +34,9 @@ stdenv.mkDerivation rec {
     lapack
   ];
 
-  cmakeFlags = [
-    "-DBUILD_SHARED_LIBS=${if stdenv.hostPlatform.isStatic then "OFF" else "ON"}"
+  mesonFlags = [
+    "-Dla_backend=netlib"
   ];
-
-  postInstall = ''
-    substituteInPlace $out/lib/cmake/${pname}/${pname}-*.cmake \
-      --replace "libgfnff.a" "libgfnff.${stdenv.hostPlatform.extensions.library}"
-  '';
 
   meta = with lib; {
     description = "A standalone library of the GFN-FF method. Extracted in large parts from the xtb program";

--- a/pkgs/apps/pysisyphus/default.nix
+++ b/pkgs/apps/pysisyphus/default.nix
@@ -109,7 +109,7 @@ let
 in
 buildPythonPackage rec {
   pname = "pysisyphus";
-  version = "0.8.0b0";
+  version = "unstable-2024-03-18";
 
   nativeBuildInputs = [ makeWrapper setuptools-scm ];
 
@@ -154,25 +154,13 @@ buildPythonPackage rec {
   src = fetchFromGitHub {
     owner = "eljost";
     repo = pname;
-    rev = version;
-    hash = "sha256-KNE61U7b+KcPDrThuSDBAGiPjPP5U7CBfuGPr8HkYaw=";
+    rev = "8f18b82d14e4558dc00f39e4a1f42eaea2adb3de";
+    hash = "sha256-NJIxLhCBv6eYi6y3YYbIDxAfdF9eFSkWXRxgzZHk65w=";
   };
-
-  patches = [
-    # Fixes for new Scipy and Numpy versions, removable on next release
-    (fetchpatch {
-      url = "https://github.com/eljost/pysisyphus/commit/8ccda1f43b00ff2c82d8f6d872ead3f4b700367d.patch";
-      hash = "sha256-aWZlJLKP8Bvqjb8gojuKUiPjGA4b5CjztWEk5DHyI74=";
-    })
-    (fetchpatch {
-      url = "https://github.com/eljost/pysisyphus/commit/99530586cca988e53b6f361af6247dfbfccf728c.patch";
-      hash = "sha256-I7Ef+LYNi7VnYFRYlgSPj3NLtWXwAmAuucu3sskhXsk=";
-    })
-  ];
 
   format = "pyproject";
 
-  preBuild = "export SETUPTOOLS_SCM_PRETEND_VERSION=${version}";
+  preBuild = "export SETUPTOOLS_SCM_PRETEND_VERSION=0.8.0b1";
 
   nativeCheckInputs = [
     openssh
@@ -182,7 +170,6 @@ buildPythonPackage rec {
 
   preCheck = ''
     export PYSISRC=${pysisrc}
-    cat ${pysisrc}
     export PATH=$PATH:${binSearchPath}
     export XTBPATH=${xtb}/share/xtb
   '';

--- a/pkgs/apps/xtb/build.patch
+++ b/pkgs/apps/xtb/build.patch
@@ -1,0 +1,17 @@
+diff --git a/meson/meson.build b/meson/meson.build
+index 3554d12..6c5d275 100644
+--- a/meson/meson.build
++++ b/meson/meson.build
+@@ -198,6 +198,12 @@ mctc_dep = dependency(
+ )
+ lib_deps += mctc_dep
+ 
++dftd4_dep = dependency('dftd4')
++lib_deps += dftd4_dep
++
++multicharge_dep = dependency('multicharge')
++lib_deps += multicharge_dep
++
+ # Get light-weight tight-binding framework dependency
+ tblite_dep = dependency(
+   'tblite',

--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -3,7 +3,9 @@
 , gfortran
 , fetchFromGitHub
 , fetchpatch
-, cmake
+, meson
+, ninja
+, pkg-config
 , makeWrapper
 , blas
 , lapack
@@ -15,6 +17,8 @@
 , simple-dftd3
 , dftd4
 , multicharge
+, cpcm-x
+, git
 , enableTurbomole ? false
 , turbomole
 , enableOrca ? false
@@ -36,21 +40,26 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "xtb";
-  version = "6.6.1";
+  version = "6.7.0";
 
   src = fetchFromGitHub {
     owner = "grimme-lab";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-I2K87W/b/Nh2VCkINhmCwe4HwBZ7ZIYM5cUYc/8Hkws=";
+    hash = "sha256-H/htbxEFYWo4niWjcrjX4ffdmW0FIzFTAVnYbn2514Y=";
   };
+
+  patches = [ ./build.patch ];
 
   outputs = [ "out" "dev" ];
 
   nativeBuildInputs = [
     gfortran
-    cmake
+    meson
+    ninja
+    pkg-config
     makeWrapper
+    git
   ];
 
   buildInputs = [
@@ -63,25 +72,10 @@ stdenv.mkDerivation rec {
     simple-dftd3
     dftd4
     multicharge
+    cpcm-x
   ];
 
   hardeningDisable = [ "format" ];
-
-  postInstall = ''
-    mkdir -p $out/lib/pkgconfig
-
-    cat > $out/lib/pkgconfig/xtb.pc << EOF
-    prefix=$out
-    libdir=''${prefix}/lib
-    includedir=''${prefix}/include
-
-    Name: ${pname}
-    Description: ${description}
-    Version: ${version}
-    Cflags: -I''${prefix}/include
-    Libs: -L''${prefix}/lib -lxtb
-    EOF
-  '';
 
   postFixup = ''
     wrapProgram $out/bin/xtb \

--- a/pkgs/lib/cpcm-x/build.patch
+++ b/pkgs/lib/cpcm-x/build.patch
@@ -1,0 +1,34 @@
+diff --git a/config/meson.build b/config/meson.build
+index 25ea458..97c2c86 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -111,13 +111,8 @@ numsa_dep = dependency(
+ )
+ lib_deps += numsa_dep
+ 
++mctc_dep = dependency('mctc-lib')
++lib_deps += mctc_dep
+ 
+-tomlf_prj = subproject(
+-  'toml-f',
+-  version: '>=0.2',
+-  default_options: [
+-    'default_library=static',
+-  ],
+-)
+-tomlf_dep = tomlf_prj.get_variable('tomlf_dep')
++tomlf_dep = dependency('toml-f')
+ lib_deps += tomlf_dep
+diff --git a/meson.build b/meson.build
+index d6241a9..11b8e05 100644
+--- a/meson.build
++++ b/meson.build
+@@ -21,7 +21,7 @@ project(
+   meson_version: '>=0.60.0',
+   default_options: [
+     'buildtype=debugoptimized',
+-    'default_library=static',
++    'default_library=both',
+   ],
+ )
+ 

--- a/pkgs/lib/cpcm-x/default.nix
+++ b/pkgs/lib/cpcm-x/default.nix
@@ -1,0 +1,63 @@
+{ stdenv
+, lib
+, gfortran
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, numsa
+, mctc-lib
+, test-drive
+, lapack
+, blas
+, toml-f
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "CPCM-X";
+  version = "unstable-2024-03-04";
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = pname;
+    rev = "7de0d7be85a10a19d60220a8d25eaa750f282019";
+    hash = "sha256-wfK+dyyggpCCCOcADxny1Ee/zfK3JN+g6jFZdksMlT8=";
+  };
+
+  # Adds non-declared mctc-lib dependency and avoids subproject download
+  patches = [ ./build.patch ];
+
+  postPatch = ''
+    substituteInPlace config/install-mod.py \
+      --replace "#!/usr/bin/env python" "#!/usr/bin/env python3"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    gfortran
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    mctc-lib
+    (lib.getDev mctc-lib)
+    test-drive
+    lapack
+    blas
+    toml-f
+    numsa
+  ];
+
+  meta = with lib; {
+    description = "Extended conductor-like polarizable continuum solvation model";
+    homepage = "https://github.com/grimme-lab/CPCM-X";
+    license = licenses.lgpl3Only;
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/lib/numsa/build.patch
+++ b/pkgs/lib/numsa/build.patch
@@ -1,0 +1,67 @@
+diff --git a/config/meson.build b/config/meson.build
+index 0c8ae76..bc0d666 100644
+--- a/config/meson.build
++++ b/config/meson.build
+@@ -43,21 +43,6 @@ if get_option('openmp')
+   lib_deps += omp_dep
+ endif
+ 
+-# Create the tool chain library as subproject
+-mctc_prj = subproject(
+-  'mctc-lib',
+-  version: '>=0.1',
+-  default_options: [
+-    'default_library=static',
+-  ],
+-)
+-mctc_dep = mctc_prj.get_variable('mctc_dep')
+-lib_deps += mctc_dep
+-inc_dirs += mctc_prj.get_variable('mctc_inc')
+ 
+-if install
+-  install_data(
+-    mctc_prj.get_variable('mctc_lic'),
+-    install_dir: get_option('datadir')/'licenses'/meson.project_name()/'mctc-lib'
+-  )
+-endif
++mctc_dep = dependency('mctc-lib', version : '>=0.2.0')
++lib_deps += mctc_dep
+diff --git a/meson.build b/meson.build
+index 7de0b65..5352b8b 100644
+--- a/meson.build
++++ b/meson.build
+@@ -25,7 +25,7 @@ project(
+     'default_library=both',
+   ],
+ )
+-install = not (meson.is_subproject() and get_option('default_library') == 'static')
++install = true
+ 
+ # General configuration information
+ lib_deps = []
+diff --git a/test/meson.build b/test/meson.build
+index c60e4a4..8537744 100644
+--- a/test/meson.build
++++ b/test/meson.build
+@@ -14,20 +14,7 @@
+ # You should have received a copy of the GNU Lesser General Public License
+ # along with numsa.  If not, see <https://www.gnu.org/licenses/>.
+ 
+-# Create mstore as subproject for testing
+-mstore_prj = subproject(
+-  'mstore',
+-  version: '>=0.1',
+-  required: not meson.is_subproject(),
+-  default_options: [
+-    'default_library=static',
+-  ],
+-)
+-# If we do not find mstore and are a subproject, we just skip testing
+-if not mstore_prj.found()
+-   subdir_done()
+-endif
+-mstore_dep = mstore_prj.get_variable('mstore_dep')
++mstore_dep = dependency('mstore')
+ 
+ tests = [
+   'surface',

--- a/pkgs/lib/numsa/default.nix
+++ b/pkgs/lib/numsa/default.nix
@@ -1,0 +1,60 @@
+{ stdenv
+, lib
+, gfortran
+, fetchFromGitHub
+, meson
+, ninja
+, pkg-config
+, mctc-lib
+, mstore
+, test-drive
+, blas
+, lapack
+, python3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "numsa";
+  version = "unstable-2024-03-04";
+
+  src = fetchFromGitHub {
+    owner = "grimme-lab";
+    repo = pname;
+    rev = "e1494543d5ab5c5dd60e5622f7b80043d63561bd";
+    hash = "sha256-kpiviWepjgpP38IqeAgxbvEn6bIkkelfFHjC6Eg7E9g=";
+  };
+
+  # Avoid subproject downloads and use nix dependencies
+  patches = [ ./build.patch ];
+
+  postPatch = ''
+    substituteInPlace ./config/install-mod.py \
+      --replace "#!/usr/bin/env python" "#!/usr/bin/env python3"
+  '';
+
+  outputs = [ "out" "dev" ];
+
+  nativeBuildInputs = [
+    gfortran
+    meson
+    ninja
+    pkg-config
+    python3
+  ];
+
+  buildInputs = [
+    mctc-lib
+    mstore
+    test-drive
+    blas
+    lapack
+  ];
+
+  meta = with lib; {
+    description = "Solvent accessible surface area calculation";
+    homepage = "https://github.com/grimme-lab/numsa";
+    license = with licenses ; [ lgpl3Only gpl3Only ];
+    platforms = platforms.linux;
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
This updates packages of the xTB ecosystem, namely mainly xTB and crest. It also switches over to a meson+ninja based build, after the CMake builds turned out to be broken https://github.com/grimme-lab/xtb/issues/981 and the fortran ecosystem dependencies are also switched over to meson+ninja https://github.com/NixOS/nixpkgs/pull/299273

https://github.com/NixOS/nixpkgs/pull/299273 needs to be merged first and a flake update will be required