### PR TITLE
xtb: fix pkg-config file

### DIFF
--- a/pkgs/apps/xtb/default.nix
+++ b/pkgs/apps/xtb/default.nix
@@ -49,7 +49,10 @@ stdenv.mkDerivation rec {
     hash = "sha256-H/htbxEFYWo4niWjcrjX4ffdmW0FIzFTAVnYbn2514Y=";
   };
 
-  patches = [ ./build.patch ];
+  patches = [
+    ./build.patch
+    ./pkg-config.patch
+  ];
 
   outputs = [ "out" "dev" ];
 

--- a/pkgs/apps/xtb/pkg-config.patch
+++ b/pkgs/apps/xtb/pkg-config.patch
@@ -1,0 +1,12 @@
+diff --git a/assets/templates/xtb.pc b/assets/templates/xtb.pc
+index d7eae88..457a1e9 100644
+--- a/assets/templates/xtb.pc
++++ b/assets/templates/xtb.pc
+@@ -1,6 +1,6 @@
+ prefix=@prefix@
+ libdir=${prefix}/@libdir@
+-includedir=${prefix}/@includedir@
++includedir=@includedir@
+ 
+ Name: @name@
+ Description: @description@


### PR DESCRIPTION
Fixes the xtb pkg-config file, which, again, included a doubled prefix path in the includedir.