### PR TITLE
mdtraj: move cython to nativeBuildInputs

### DIFF
--- a/pkgs/lib/mdtraj/default.nix
+++ b/pkgs/lib/mdtraj/default.nix
@@ -31,9 +31,12 @@ buildPythonPackage rec {
 
   buildInputs = [ zlib ];
 
+  nativeBuildInputs = [
+    cython
+  ];
+
   propagatedBuildInputs = [
     setuptools
-    cython
     numpy
     pyparsing
     astunparse


### PR DESCRIPTION
This fixes an issue I'm having using the overlay with recent nixpkgs versions, where `cython` must be overriden to `cython_0` (since mdtraj needs 0.x), and this causes a collision in the environment when other packages propagate a different cython version.

My understanding is that because cython is [declared as a build-system dependency](https://github.com/mdtraj/mdtraj/blob/43d8194bbc2e7f97a74b69fa02708bf17589529e/pyproject.toml#L7), it's more appropriate to put it in `nativeBuildInputs` (and this also fixes the collision issue).