### PR TITLE
ambertools: init at 24

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -113,6 +113,8 @@ let
         #
         # Applications
         #
+        ambertools = super.python3.pkgs.toPythonApplication self.python3.pkgs.ambertools;
+
         autodock-vina = callPackage ./pkgs/apps/autodock-vina { };
 
         autoint = super.python3.pkgs.toPythonApplication self.python3.pkgs.pyphspu;

--- a/pkgs/apps/ambertools/default.nix
+++ b/pkgs/apps/ambertools/default.nix
@@ -138,6 +138,7 @@ buildPythonPackage rec {
     description = "Tools for molecular mechanics and molecular dynamics with AMBER";
     homepage = "https://ambermd.org/AmberTools.php";
     license = with licenses; [ lgpl3 bsd3 mit asl20 gpl3Only gpl2Only ];
+    hydraPlatforms = [ ]; # Dont build on Hydra
     platforms = platforms.linux;
   };
 }

--- a/pkgs/apps/ambertools/default.nix
+++ b/pkgs/apps/ambertools/default.nix
@@ -1,0 +1,143 @@
+{ buildPythonPackage
+, lib
+, requireFile
+, makeWrapper
+  # Python dependencies
+, numpy
+, scipy
+, matplotlib
+, setuptools
+  # Native dependencies
+, gfortran
+, cmake
+, readline
+, perl
+, flex
+, bison
+, zlib
+, boost
+, netcdf
+, netcdffortran
+, fftw
+, blas
+, lapack
+, protobuf
+, plumed
+, apbs
+, arpack
+, runtimeShell
+}:
+
+buildPythonPackage rec {
+  pname = "AmberTools";
+  version = "24";
+
+  src = requireFile {
+    name = "AmberTools${version}.tar.bz2";
+    sha256 = "sha256-UvtPszcKibfOc4otw+UTwvwZQ/3ktDgYRtnnXMSNhA8=";
+    url = "https://ambermd.org/AmberTools.php";
+  };
+
+  nativeBuildInputs = [
+    cmake
+    gfortran
+    flex
+    bison
+    makeWrapper
+  ];
+
+  buildInputs = [
+    zlib
+    boost
+    blas
+    lapack
+    netcdffortran
+    fftw
+    protobuf
+    plumed
+    arpack
+    apbs
+    readline
+  ];
+
+  format = "other";
+
+  cmakeFlags = [
+    "-DCOMPILER=AUTO"
+    "-DDOWNLOAD_MINICONDA=OFF"
+    "-DOPENMP=ON"
+    "-DTRUST_SYSTEM_LIBS=ON"
+  ];
+
+  propagatedBuildInputs = [
+    perl
+  ];
+
+  dependencies = [
+    numpy
+    scipy
+    matplotlib
+    setuptools
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    make -j $NIX_BUILD_CORES
+
+    runHook postBuild
+  '';
+
+  installPhase =
+    let
+
+      wrongBash = [
+        "am1bcc"
+        "antechamber"
+        "atomtype"
+        "bondtype"
+        "espgen"
+        "match"
+        "match_atomname"
+        "parmcal"
+        "parmchk2"
+        "prepgen"
+        "reduce"
+        "residuegen"
+        "respgen"
+        "XrayPrep"
+      ];
+    in
+    ''
+      runHook preInstall
+
+      make install
+
+      # Some scripts hardcode /bin/bash. Not only necessary as their shebang, but
+      # some also generate bash scripts with wrong shebangs.
+      for PROG in ${builtins.toString wrongBash}; do
+        substituteInPlace $out/bin/$PROG --replace-fail '#!/bin/bash' '#!${runtimeShell}'
+      done
+
+      substituteInPlace $out/amber-interactive.sh --replace-fail '#! /bin/bash' '#!${runtimeShell}'
+
+      # Avoids sourcing amber.sh before running ambertools by setting the required
+      # variables via wrappers for each program.
+      for PROG in $out/bin/*; do
+        if [[ -f $PROG ]]; then
+          wrapProgram $PROG \
+            --set AMBERHOME $out \
+            --set QUICK_BASIS=$out/AmberTools/src/quick/basis
+        fi
+      done
+
+      runHook postInstall
+    '';
+
+  meta = with lib; {
+    description = "Tools for molecular mechanics and molecular dynamics with AMBER";
+    homepage = "https://ambermd.org/AmberTools.php";
+    license = with licenses; [ lgpl3 bsd3 mit asl20 gpl3Only gpl2Only ];
+    platforms = platforms.linux;
+  };
+}

--- a/pythonPackages.nix
+++ b/pythonPackages.nix
@@ -45,6 +45,8 @@ let
 
     theodore = callPackage ./pkgs/apps/theodore { };
 
+    ambertools = callPackage ./pkgs/apps/ambertools { };
+
     pdbfixer = callPackage ./pkgs/apps/pdbfixer { };
 
     polyply = callPackage ./pkgs/apps/polyply { };


### PR DESCRIPTION
Adds the AmberTools, the programs required to set up a MM simulation for Amber itself, but also for many other programs, that read Amber files such as CP2K, NWchem, Gromacs, OpenMM, NAMD, ...

The installation is relatively wild. AmberTools 

  * vendors half the universe (NetCDF, Boost, BLAS, LAPACK, Packmol)
  * wants to download Miniconda in CMake to provide its own Python
  * refuses to use an installed Boost library
  * hardcodes `/bin/bash` in multiple locations, not only in shebangs, but also in python scripts, that then generate bash scripts
  * uses magic scripts that should be sourced before running any program from the AmberTools
  * Tries to update its own sources when calling cmake
  * uses bash wrappers around cmake
  * is half a python package that doesn't use python tooling but cmake and requires a `format = "other";` build.
  * Says it is mostly GPL3 on the web page, but requires a mail address and institution for downloading. The readme says it may not be redistributed, while the license clearly says otherwise and lists a funny mix of licenses from BSD3, ASL 2.0, LGPL, GPL3 and 2, MIT and other commong OpenSource Licenses.
 

I've tried to circumvent all these peculiar decisions as good as possible. Most libraries should now be system libraries but I think some subprograms still build their own NetCDF, despite other parts of Cmake finding it. As far as I can tell it should mostly work now.