### PR TITLE
lib: fix by-name path construction

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -23,7 +23,7 @@
   pkgs-by-name = callPackage: dir: let
     path = builtins.path { path = dir; name = "pkgs-by-name";};
   in
-    lib.mapAttrs (pkg: _: callPackage "${path}/${pkg}/package.nix" {})
+    lib.mapAttrs (pkg: _: callPackage (path + "/${pkg}/package.nix") {})
     (lib.filterAttrs (_: type: type == "directory") (builtins.readDir path));
 
 }


### PR DESCRIPTION
Using a + instead of string interpolation allows to find paths in the directory tree instead of /nix/store. This is required for use  with nix-update