### PR TITLE
xtb: 6.7.0 -> 6.7.1

### DIFF
--- a/pkgs/by-name/xtb/package.nix
+++ b/pkgs/by-name/xtb/package.nix
@@ -40,13 +40,13 @@ let
 in
 stdenv.mkDerivation rec {
   pname = "xtb";
-  version = "6.7.0";
+  version = "6.7.1";
 
   src = fetchFromGitHub {
     owner = "grimme-lab";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-H/htbxEFYWo4niWjcrjX4ffdmW0FIzFTAVnYbn2514Y=";
+    hash = "sha256-+qgXSMwzD0xSycZIRTokt77fZHHZQ++Npzr7NLlypOA=";
   };
 
   patches = [


### PR DESCRIPTION
Compatibility release for upcoming ORCA 6: https://github.com/grimme-lab/xtb/releases/tag/v6.7.1