### PR TITLE
crest: 3.0.1 -> 3.0.2

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -124,8 +124,8 @@ let
             src = super.fetchFromGitHub {
               owner = "tblite";
               repo = "tblite";
-              rev = "1bd936ca81f6f9ec9bbe65e32bc422ff5388571b";
-              hash = "sha256-ywXpnKU5CkPSp4zfJkFvrN09ptjt3tqq2zSqPcHAv6E=";
+              rev = "4556e28f391573b3c80c94beb7c56313005d5269";
+              hash = "sha256-JmTEnvYqA73vmWQe4cpjvp6/Wwb+elSMDdHTPwD3/jc=";
             };
           });
         };

--- a/pkgs/by-name/crest/package.nix
+++ b/pkgs/by-name/crest/package.nix
@@ -27,13 +27,13 @@ let lwoniom = fetchFromGitHub {
 
 in stdenv.mkDerivation rec {
   pname = "crest";
-  version = "3.0.1";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "crest-lab";
     repo = pname;
     rev = "v${version}";
-    hash = "sha256-YwPM43jVmiwQOCMXN8tyoxLHtPm36C7N+fEvYsVTp3A=";
+    hash = "sha256-AVLCC5banxmBQX8tuN2zSQbM7wKwrymfXLT5MBQSpPY=";
   };
 
   patches = [ ./build.patch ];

--- a/pkgs/by-name/gfn0/package.nix
+++ b/pkgs/by-name/gfn0/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gfn0";
-  version = "unstable-2024-03-07";
+  version = "unstable-2024-07-18";
 
   src = fetchFromGitHub {
     owner = "pprcht";
     repo = pname;
-    rev = "1701599ca4298ecb5c3741a9e56d67ce03e9e4c3";
-    hash = "sha256-slUShllJ3shUZaEnEIhy6QbDzteNSlbLrokPKgYhG7I=";
+    rev = "584cec4b47da23bf3634ef0dd798a1639fcc5e47";
+    hash = "sha256-DULglQ144lLWK7sJkOEtMVmEIokOhYmrH6myBtfcNaA=";
   };
 
   patches = [ ./build.patch ];

--- a/pkgs/by-name/gfnff/package.nix
+++ b/pkgs/by-name/gfnff/package.nix
@@ -11,13 +11,13 @@
 
 stdenv.mkDerivation rec {
   pname = "gfnff";
-  version = "unstable-2024-02-14";
+  version = "unstable-2024-08-02";
 
   src = fetchFromGitHub {
     owner = "pprcht";
     repo = pname;
-    rev = "4d68ac1ab8df5999d3493715a86c13786bac6bfb";
-    hash = "sha256-K1KwfrMqnXi1Mj3PDGYgHdG9WLuXFtrNqtfeL5wkDtI=";
+    rev = "42963235cba66f81575f17b2dba8be7acf2a440d";
+    hash = "sha256-Og/RL33Jz9okweq18NIKNsOYay+BF9qZHv9zlELMozI=";
   };
 
   patches = [ ./build.patch ];


### PR DESCRIPTION
Updates crest and its dependencies gfnff and gfn0 to the latest versions.

https://github.com/crest-lab/crest/releases/tag/v3.0.2