### PR TITLE
Python 3.12 compatibility for Psi4

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -178,7 +178,7 @@ let
 
         polyply = super.python3.pkgs.toPythonApplication self.python3.pkgs.polyply;
 
-        psi4 = super.python311.pkgs.toPythonApplication self.python311.pkgs.psi4;
+        psi4 = super.python3.pkgs.toPythonApplication self.python311.pkgs.psi4;
 
         pysisyphus = super.python3.pkgs.toPythonApplication self.python3.pkgs.pysisyphus;
 

--- a/pkgs/python-by-name/gau2grid/distutils.patch
+++ b/pkgs/python-by-name/gau2grid/distutils.patch
@@ -1,0 +1,19 @@
+diff --git a/cmake/FindPythonLibsNew.cmake b/cmake/FindPythonLibsNew.cmake
+index dc44a9d..15dccf3 100644
+--- a/cmake/FindPythonLibsNew.cmake
++++ b/cmake/FindPythonLibsNew.cmake
+@@ -73,11 +73,11 @@ endif()
+ # The library suffix is from the config var LDVERSION sometimes, otherwise
+ # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
+ execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
+-    "from distutils import sysconfig as s;import sys;import struct;
++    "import sysconfig as s;import sys;import struct;
+ print('.'.join(str(v) for v in sys.version_info));
+ print(sys.prefix);
+-print(s.get_python_inc(plat_specific=True));
+-print(s.get_python_lib(plat_specific=True));
++print(s.get_path('platinclude', 'posix_prefix'));
++print(s.get_path('platlib'));
+ print(s.get_config_var('SO'));
+ print(hasattr(sys, 'gettotalrefcount')+0);
+ print(struct.calcsize('@P'));

--- a/pkgs/python-by-name/gau2grid/package.nix
+++ b/pkgs/python-by-name/gau2grid/package.nix
@@ -34,11 +34,14 @@ buildPythonPackage rec {
     rev = "v" + version;
   };
 
+  patches = [
+    ./distutils.patch
+  ];
+
   meta = with lib; {
     description = "Fast computation of a gaussian and its derivative on a grid";
     homepage = "https://github.com/dgasmith/gau2grid";
     license = licenses.bsd3;
     platforms = platforms.all;
-    broken = pythonAtLeast "3.12";
   };
 }

--- a/pkgs/python-by-name/optking/package.nix
+++ b/pkgs/python-by-name/optking/package.nix
@@ -10,13 +10,13 @@
 
 buildPythonPackage rec {
   pname = "optking";
-  version = "0.2.1";
+  version = "0.3.0";
 
   src = fetchFromGitHub {
     owner = "psi-rking";
     repo = "optking";
-    rev = "3025f85c47df308c4482341129db9ad5ebc82c6a"; # Tag keeps moving
-    hash = "sha256-mXLBsc4PQjeTjUg0nzf9PI0FF81y77yCJ5l+g47uoD8=";
+    rev = version;
+    hash = "sha256-vHoxmJAfuGHiqXIOb935X1ezTT6AYmTWnLeJZSiB1KY=";
   };
 
   propagatedBuildInputs = [
@@ -34,7 +34,5 @@ buildPythonPackage rec {
     homepage = "https://github.com/psi-rking/optking";
     license = licenses.bsd3;
     platforms = platforms.unix;
-    broken = pythonAtLeast "3.12";
-
   };
 }


### PR DESCRIPTION
This should fix Psi4 and its dependencies for Python 3.12.

  * gau2grid: switch out distutils functions for setuptools functions via a patch
  * optking: updates to release 0.3.0, which is compatible to 3.12

