### PR TITLE
dftbplus python 3.12

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -130,7 +130,7 @@ let
           });
         };
 
-        dftbplus = super.python311.pkgs.toPythonApplication self.python311.pkgs.dftbplus;
+        dftbplus = super.python3.pkgs.toPythonApplication self.python311.pkgs.dftbplus;
 
         dirac = callPackage ./pkgs/by-name/dirac/package.nix {
           inherit (self) exatensor;

--- a/pkgs/python-by-name/dftbplus/distutils.patch
+++ b/pkgs/python-by-name/dftbplus/distutils.patch
@@ -1,0 +1,22 @@
+diff --git a/tools/dptools/setup.py b/tools/dptools/setup.py
+index a7aa36e6..0106c007 100644
+--- a/tools/dptools/setup.py
++++ b/tools/dptools/setup.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-from distutils.core import setup
++from setuptools import setup
+ 
+ setup(
+     name="dptools",
+diff --git a/tools/pythonapi/setup.py b/tools/pythonapi/setup.py
+index 4188736f..424ea0ca 100644
+--- a/tools/pythonapi/setup.py
++++ b/tools/pythonapi/setup.py
+@@ -1,5 +1,5 @@
+ #!/usr/bin/env python3
+-from distutils.core import setup
++from setuptools import setup
+ 
+ setup(
+     name='pythonapi',

--- a/pkgs/python-by-name/dftbplus/package.nix
+++ b/pkgs/python-by-name/dftbplus/package.nix
@@ -1,6 +1,5 @@
 { buildPythonPackage
 , lib
-, pythonAtLeast
 , gfortran
 , fetchFromGitHub
 , cmake
@@ -9,35 +8,33 @@
 , lapack
 , mpi
 , scalapack
-, dftd4
 , numpy
+, setuptools
 }:
 
 assert !blas.isILP64 && !lapack.isILP64;
 
 buildPythonPackage rec {
   pname = "dftbplus";
-  version = "24.1";
+  version = "unstable-2024-08-23";
 
   src = fetchFromGitHub {
     owner = "dftbplus";
     repo = pname;
-    rev = version;
-    hash = "sha256-lI0l977SYHIgPKZ9037q7IYudAck2vyI2byW0vBB680=";
+    rev = "3f8a8d15a577ca039950ebbdb6c120667aca5728";
+    hash = "sha256-AJSDBd1BBHYvhVmJPYP7R0UmEiOeUMJlMtX8zdutJMI=";
     fetchSubmodules = true;
   };
 
   postPatch = ''
     patchShebangs .
-
-    substituteInPlace tools/dptools/CMakeLists.txt \
-      --replace-fail '$DESTDIR/' ""
   '';
 
   nativeBuildInputs = [
     gfortran
     cmake
     pkg-config
+    setuptools
   ];
 
   buildInputs = [
@@ -62,10 +59,10 @@ buildPythonPackage rec {
     "-DWITH_TBLITE=OFF"
     "-DWITH_SDFTD3=OFF"
     "-DWITH_PYTHON=ON"
+    "-DENABLE_DYNAMIC_LOADING=ON"
+    "-DBUILD_SHARED_LIBS=ON"
     "-DSCALAPACK_LIBRARY=${scalapack}/lib/libscalapack.so"
   ];
-
-  pythonImportsCheck = [ "dptools" ];
 
   meta = with lib; {
     description = "DFTB+ general package for performing fast atomistic simulations";
@@ -73,6 +70,5 @@ buildPythonPackage rec {
     license = with licenses; [ gpl3Plus lgpl3Plus ];
     platforms = platforms.linux;
     maintainers = [ maintainers.sheepforce ];
-    broken = pythonAtLeast "3.12";
   };
 }


### PR DESCRIPTION
Updates to DFTB+ with Python 3.12 fixes. dptools would need to be explicitly installed now. However, the python scripts work well with Python 3.12 and are now probably installed by CMake via Pyproject instead of distutils.