### PR TITLE
dftbplus: use python3 instead of python311 in the overlay

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -130,7 +130,7 @@ let
           });
         };
 
-        dftbplus = super.python3.pkgs.toPythonApplication self.python311.pkgs.dftbplus;
+        dftbplus = super.python3.pkgs.toPythonApplication self.python3.pkgs.dftbplus;
 
         dirac = callPackage ./pkgs/by-name/dirac/package.nix {
           inherit (self) exatensor;


### PR DESCRIPTION
Oversight from #522, sorry :grimacing: 