### PR TITLE
pysisyphus & hydra evaluation

### DIFF
--- a/pkgs/python-by-name/pysisyphus/package.nix
+++ b/pkgs/python-by-name/pysisyphus/package.nix
@@ -26,7 +26,6 @@
 , psutils
 , qcengine
 , ase
-, xtb-python
 , openbabel-bindings
 , pyscf
   # Runtime dependencies
@@ -135,7 +134,6 @@ buildPythonPackage rec {
     openssh
     pyscf
   ] # Syscalls
-  ++ lib.optional enableXtb xtb-python
   ++ lib.optional enableXtb xtb
   ++ lib.optional enableJmol jmol
   ++ lib.optional enableMultiwfn multiwfn


### PR DESCRIPTION
This removes the xtb-python support form pysisyphus, to avoid hydra evaluation errors. Also, xtb-python is outdated.