### PR TITLE
psi4: fix python version in overlay.nix

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -178,7 +178,7 @@ let
 
         polyply = super.python3.pkgs.toPythonApplication self.python3.pkgs.polyply;
 
-        psi4 = super.python3.pkgs.toPythonApplication self.python311.pkgs.psi4;
+        psi4 = super.python3.pkgs.toPythonApplication self.python3.pkgs.psi4;
 
         pysisyphus = super.python3.pkgs.toPythonApplication self.python3.pkgs.pysisyphus;
 


### PR DESCRIPTION
Fix Psi4 evaluation at the application level layer.