### PR TITLE
quantum-espresso evaluation

### DIFF
--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -49,7 +49,10 @@ let
       enableCuda = cfg.useCuda;
       stdenv = final.clangStdenv;
     };
-    quantum-espresso = recallPackage quantum-espresso { hdf5 = final.hdf5-fortran; };
+    quantum-espresso = recallPackage quantum-espresso {
+      hdf5 = final.hdf5-fortran;
+      wannier90 = final.wannier90;
+    };
     pcmsolver = recallPackage pcmsolver {};
     scalapack = recallPackage scalapack {};
     siesta = recallPackage siesta {};


### PR DESCRIPTION
Somehow the `recallPackage` of `quantum-espresso` passes a wrong wannier90, that fails to link. I'm setting the `wannier90` attribute explicitly to fix that issue.