### PR TITLE
orca: add otool_external hook for external optimizer

### DIFF
--- a/pkgs/by-name/orca/package.nix
+++ b/pkgs/by-name/orca/package.nix
@@ -15,12 +15,11 @@ stdenv.mkDerivation {
 
   src =
     if enableAvx2 then
-      requireFile
-        {
+      requireFile {
           name = "orca_6_0_0_linux_x86-64_avx2_shared_openmpi416.tar.xz";
           sha256 = "sha256-AsISlO/nsbch4my5D5juFa1oLQKAcgG30hff5nkFov0=";
           url = "https://orcaforum.kofo.mpg.de/app.php/portal";
-        } else
+      } else
       requireFile {
         name = "orca_6_0_0_linux_x86-64_shared_openmpi416.tar.xz";
         sha256 = "sha256-IZvR3rbWSmPLckcZJsuBZly7zewZ+clUl2G+Z9SaKcY=";

--- a/pkgs/by-name/orca/package.nix
+++ b/pkgs/by-name/orca/package.nix
@@ -7,7 +7,14 @@
 , openssh
 , xtb
 , enableAvx2 ? true
+
+# Provide path to a custom script for otool_external
+, withCustomOtoolExternal ? false
+, customOtoolExternal ? null
 }:
+
+
+assert withCustomOtoolExternal -> customOtoolExternal != null;
 
 stdenv.mkDerivation {
   pname = "orca";
@@ -30,6 +37,8 @@ stdenv.mkDerivation {
   buildInputs = [ openmpi stdenv.cc.cc.lib ];
 
   installPhase = ''
+    runHook preInstall
+
     mkdir -p $out/bin $out/lib $out/share/doc/orca
 
     cp autoci_* $out/bin
@@ -48,6 +57,9 @@ stdenv.mkDerivation {
     wrapProgram $out/bin/orca --prefix PATH : '${lib.getBin openmpi}/bin:${lib.getBin openssh}/bin'
 
     ln -s ${lib.getBin xtb}/bin/xtb $out/bin/otool_xtb
+    ${lib.optionalString withCustomOtoolExternal "ln -s ${customOtoolExternal} $out/bin/otool_external"}
+
+    runHook postInstall
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
As described in section 9.24.6 in the ORCA manual, ORCA can use an external program for geometry optimization.
However, this script needs to be right next to the ORCA executables. 

We provide two options now:
1. A simple wrapper that forwards the command to a script set in $ORCA_OTOOL_EXTERNAL (default)
2. Fully declarative: provide a path to a script via inputs (requires orca rebuild).

