### PR TITLE
gamess-us: 2023R1P1 -> 2024R2P1

### DIFF
--- a/pkgs/by-name/gamess-us/gcc-config.patch
+++ b/pkgs/by-name/gamess-us/gcc-config.patch
@@ -1,40 +1,34 @@
 diff --git a/comp b/comp
-index 3cdf0a9..0fc9da2 100755
+index 52602ff..1cb96ac 100755
 --- a/comp
 +++ b/comp
-@@ -1260,6 +1260,7 @@ if ($TARGET == ibm64) then
+@@ -1289,6 +1289,7 @@ if ($TARGET == ibm64) then
              case 12.1:
              case 12.2:
              case 12.3:
 +            case 12.4:
              case 13.1:
-                if ($GMS_MATHLIB == libflame) then
-                   #keeping these in to fix exam30
-@@ -2209,6 +2210,7 @@ if ($TARGET == linux64) then
-             case 12.1:
-             case 12.2:
-             case 12.3:
-+            case 12.4:
-             case 13.1:
-                if ($GMS_MATHLIB == libflame) then
+                if ($GMS_MATHLIB == aocl) then
                    #keeping these in to fix exam30
 diff --git a/config b/config
-index 2cb4dfc..6991eb3 100755
+index 249235f..781bd17 100755
 --- a/config
 +++ b/config
-@@ -506,6 +506,7 @@ badibmfortran:
-                case 12.1:
-                case 12.2:
-                case 12.3:
-+               case 12.4:
-                case 13.1:
-                   echo "   Good, the newest gfortrans can compile REAL*16 data type."
-                   echo "   Please report any numerical issues you encounter."
-@@ -846,6 +847,7 @@ badlinuxfortran:
-                case 12.1:
-                case 12.2:
-                case 12.3:
-+               case 12.4:
-                case 13.1:
+@@ -460,7 +460,7 @@ badibmfortran:
+                case 9.[1-5]:
+                case 10.[1-5]:
+                case 11.[1-4]:
+-               case 12.[1-3]:
++               case 12.[1-4]:
+                case 13.[1-3]:
+                case 14.[1]:
                    echo "   Good, the newest gfortran version number ${GMS_GFORTRAN_VERNO} can compile REAL*16 data type."
-                   echo "   Please report any numerical issues you encounter."
+@@ -771,7 +771,7 @@ badlinuxfortran:
+                case 9.[1-5]:
+                case 10.[1-5]:
+                case 11.[1-4]:
+-               case 12.[1-3]:
++               case 12.[1-4]:
+                case 13.[1-3]:
+                case 14.[1]:
+                   echo "   Good, the newest gfortran version number ${GMS_GFORTRAN_VERNO} can compile REAL*16 data type."

--- a/pkgs/by-name/gamess-us/openmpi.patch
+++ b/pkgs/by-name/gamess-us/openmpi.patch
@@ -1,0 +1,13 @@
+diff --git a/rungms b/rungms
+index 1eac5ee..21ced16 100755
+--- a/rungms
++++ b/rungms
+@@ -1104,7 +1104,7 @@ if ($TARGET == mpi) then
+ 
+    case orte:
+       set echo
+-      orterun -np $NPROCS --npernode $PPN2 \
++      mpiexec -np $NPROCS --npernode $PPN2 \
+               $GMSPATH/gamess.$VERNO.x < /dev/null
+       unset echo
+       breaksw

--- a/pkgs/by-name/gamess-us/package.nix
+++ b/pkgs/by-name/gamess-us/package.nix
@@ -6,13 +6,13 @@
 let target = if enableMpi then "mpi" else "sockets";
 in stdenv.mkDerivation rec {
   pname = "gamess-us";
-  version = "2023R1P1";
+  version = "2024R2P1";
 
   # The website always provides "gamess-current.tar.gz". However, we expect the file to be renamed,
   # to a more reasonable name.
   src = requireFile rec {
     name = "${pname}-${version}.tar.gz";
-    sha256 = "sha256-K3z0rxf7Lqtb82Cb+CBDdyjNNth/RIV9ziW6+p6WIq0=";
+    sha256 = "sha256-mQUe3sPLh2aCLh93t7Qc+fLULOYeZnE+S1El9zV83qk=";
     url = "https://www.msg.chem.iastate.edu/gamess/download.html";
   };
 
@@ -25,6 +25,8 @@ in stdenv.mkDerivation rec {
     ./openblas.patch
     # Recognize gcc-12.4 as a valid compiler
     ./gcc-config.patch
+    # Use mpiexec in OpenMPI instead of orterun
+    ./openmpi.patch
   ];
 
   nativeBuildInputs = [


### PR DESCRIPTION
Updates GAMESS to the current version: https://www.msg.chem.iastate.edu/gamess/versions.html

EDIT: Somewhere in the refactoring of OpenMPI upstream, `orterun` was lost from `mpi.bin`. It is merely an alias to `mpiexec`. However, `rungms` wants to use `orterun`. 

  * [x] Patch rungms to use `mpiexec` instead of `orterun`.