### PR TITLE
dice: init at unstable-2024-07-02

### DIFF
--- a/nixpkgs-opt.nix
+++ b/nixpkgs-opt.nix
@@ -18,6 +18,10 @@ let
     avogadro2 = recallPackage avogadro2 {};
     arpack = recallPackage arpack {};
     arpack-mpi = recallPackage arpack { useMpi = true; };
+    boost-mpi = recallPackage boost {
+      useMpi = true;
+      inherit (self) mpi;
+    };
     cp2k = recallPackage cp2k {};
     fftw = recallPackage fftw {};
     dkh = recallPackage dkh {};

--- a/overlay.nix
+++ b/overlay.nix
@@ -132,6 +132,10 @@ let
 
         dftbplus = super.python3.pkgs.toPythonApplication self.python3.pkgs.dftbplus;
 
+        dice = callPackage ./pkgs/by-name/dice/package.nix {
+          boost = self.boost-mpi;
+        };
+
         dirac = callPackage ./pkgs/by-name/dirac/package.nix {
           inherit (self) exatensor;
         };

--- a/overlay.nix
+++ b/overlay.nix
@@ -148,6 +148,8 @@ let
 
         iboview = prev.libsForQt5.callPackage ./pkgs/apps/iboview { };
 
+        # Molcas with optimisation and LibWFA support. Note, that this disables
+        # EXPBAS support, however.
         molcas = let
           molcasOpt = prev.openmolcas.override {
             stdenv = aggressiveStdenv;
@@ -165,6 +167,16 @@ let
             cp -r ${self.libwfa.src} External/libwfa
             chmod -R u+w External/
           '';
+        });
+
+        # Molcas with DICE enabled but QCMaquis disabled
+        molcasDice = self.molcas.overrideAttrs (oldAttrs: {
+          propagatedUserEnvPkgs = [ self.dice ];
+          cmakeFlags = oldAttrs.cmakeFlags ++ [
+            "-DDMRG=OFF"
+            "-DNEVPT2=OFF"
+            "-DDICE=ON"
+          ];
         });
 
         moltemplate = super.python3.pkgs.toPythonApplication self.python3.pkgs.moltemplate;

--- a/pkgs/by-name/dice/package.nix
+++ b/pkgs/by-name/dice/package.nix
@@ -1,0 +1,64 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, boost
+, hdf5
+, eigen
+, blas
+, lapack
+, mpi
+}:
+
+
+stdenv.mkDerivation {
+  pname = "dice";
+  version = "2024-07-02";
+
+  src = fetchFromGitHub {
+    owner = "sanshar";
+    repo = "dice";
+    rev = "0f52b621b79cfef83dc161e0a30120f7cc86bd42";
+    hash = "sha256-v33uaFY9m2Aewm48iePHUuKBMkxcdMLgin10s/PYgcc=";
+  };
+
+  buildInputs = [
+    boost
+    eigen
+    hdf5
+    blas
+    lapack
+  ];
+
+  propagatedBuildInputs = [ mpi ];
+  propagatedUserEnvPkgs = [ mpi ];
+
+  makeFlags = [
+    "USE_MPI=yes"
+    "USE_INTEL=no"
+    "EIGEN=${lib.getDev eigen}/include/eigen3"
+    "BOOST_ROOT=${boost}"
+    "HDF5=${hdf5}"
+  ];
+
+  enableParallelBuilding = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share/dice}
+    cp -r bin lib $out/.
+    cp -r examples $out/share/dice
+
+    runHook postInstall
+  '';
+
+  passthru = { inherit mpi; };
+
+  meta = with lib; {
+    description = "Heatbath configuration interaction program";
+    homepage = "https://github.com/sanshar/Dice";
+    license = licenses.gpl3Only;
+    maintainers = [ maintainers.sheepforce ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds the Dice program for Heatbath CI. Can be used for large active space CASSCF in PySCF and Molcas. I've also added a version of Molcas that builds with DICE support. However, turns out there are some exclusive things going on in Molcas.

  * When buiding with `-DDMRG=ON` and `-DNEVPT2=ON` (upstream nixpkgs), you can't have `-DDICE=ON`. However, the EXPBAS module is available
  * When enabling LibWFA Support (`molcas` attribute in nixpkgs), EXPBAS support is disabled due to required `-DH5_USE_110_API` flag
  * I've added a version `molcasDice`, that disables DMRG and NEVPT2, but has DICE and LibWFA support, but not EXPBAS support. 

Conclusion; Molcas build system is sensitive and has some mutually exclusive options. Maybe it would be nice to have these things configurable, but that is not that easy with upstream molcas but our DICE and LibWFA builds.