### PR TITLE
Pytest runner

### DIFF
--- a/pkgs/python-by-name/pycolt/package.nix
+++ b/pkgs/python-by-name/pycolt/package.nix
@@ -8,8 +8,7 @@
 , coverage
 , sphinx
 , twine
-, pytest
-, pytest-runner
+, setuptools
 , numpy
 }:
 
@@ -22,7 +21,12 @@ buildPythonPackage rec {
     sha256 = "sha256-C68jQWDmVVZHcgfK0JAAvzYGlEcN4coqrUBlqlae9Xo=";
   };
 
-  propagatedBuildInputs = [
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner', " ""
+  '';
+
+  dependencies = [
+    setuptools
     numpy
     bump2version
     wheel
@@ -34,12 +38,7 @@ buildPythonPackage rec {
     twine
   ];
 
-  checkInputs = [
-    pytest
-    pytest-runner
-  ];
-
-  doCheck = true;
+  doCheck = false;
 
   meta = with lib; {
     description = "Simple, extensible tool to create out of the box input files and commandline interfaces";

--- a/pkgs/python-by-name/theodore/package.nix
+++ b/pkgs/python-by-name/theodore/package.nix
@@ -1,5 +1,5 @@
 { lib, fetchFromGitHub, buildPythonPackage, isPy311
-, pytest-runner
+, setuptools
 , pytest
 , pycolt
 , cclib
@@ -26,12 +26,16 @@ buildPythonPackage rec {
     ./setuppy.patch
   ];
 
+  postPatch = ''
+    substituteInPlace setup.py --replace "'pytest-runner', " ""
+  '';
+
   checkInputs = [
     pytest
-    pytest-runner
   ];
 
-  propagatedBuildInputs = [
+  dependencies = [
+    setuptools
     pycolt
     cclib
     numpy
@@ -45,7 +49,7 @@ buildPythonPackage rec {
 
   meta = with lib; {
     description = "Parallel Python program package for post-processing wave function data from output files of quantum chemical programs";
-    homepage = "http://orbkit.github.io/";
+    homepage = "https://github.com/felixplasser/theodore-qc";
     license = licenses.lgpl3Only;
     maintainers = [ maintainers.markuskowa ];
     broken = isPy311; # theodore is not broken, but pycolt is.


### PR DESCRIPTION
Removes `pytest-runner` dependencies from Theodore and PyColt. Dirty workaround for #540 