### PR TITLE
flake: add cachix public key to nixConfig.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
 
   nixConfig = {
     extra-substituters = [ "https://nix-qchem.cachix.org" ];
+    extra-trusted-public-keys = [ "nix-qchem.cachix.org-1:ZjRh1PosWRj7qf3eukj4IxjhyXx6ZwJbXvvFk3o3Eos=" ];
 
     allow-import-from-derivation = "true";
   };


### PR DESCRIPTION
This makes it more user friendly. The user just needs to accept the setting instead of manually adding it to nix.conf.

See also https://github.com/Nix-QChem/NixOS-QChem/issues/568