### PR TITLE
orca: make AVX2 selection dependent on hostPlatform flags

### DIFF
--- a/pkgs/by-name/orca/package.nix
+++ b/pkgs/by-name/orca/package.nix
@@ -6,7 +6,7 @@
 , openmpi
 , openssh
 , xtb
-, enableAvx2 ? true
+, enableAvx2 ? stdenv.hostPlatform.avx2Support
 
 # Provide path to a custom script for otool_external
 , withCustomOtoolExternal ? false


### PR DESCRIPTION
Makes it consistent with global config of stdenv.