### PR TITLE
gauxc: init at unstable-2024-09-20

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -140,6 +140,10 @@ let
           inherit (self) exatensor;
         };
 
+        exchcxx = callPackage ./pkgs/by-name/exchcxx/package.nix {
+          inherit cfg;
+        };
+
         gamess-us = callPackage ./pkgs/by-name/gamess-us/package.nix {
           gfortran = final.gfortran12;
         };

--- a/overlay.nix
+++ b/overlay.nix
@@ -152,6 +152,10 @@ let
 
         gau2grid = super.python3.pkgs.toPythonApplication self.python3.pkgs.gau2grid;
 
+        gauxc = callPackage ./pkgs/by-name/gauxc/package.nix {
+          inherit cfg;
+        };
+
         iboview = prev.libsForQt5.callPackage ./pkgs/apps/iboview { };
 
         # Molcas with optimisation and LibWFA support. Note, that this disables

--- a/overlay.nix
+++ b/overlay.nix
@@ -146,6 +146,8 @@ let
 
         gator = super.python3.pkgs.toPythonApplication self.python3.pkgs.gator;
 
+        gau2grid = super.python3.pkgs.toPythonApplication self.python3.pkgs.gau2grid;
+
         iboview = prev.libsForQt5.callPackage ./pkgs/apps/iboview { };
 
         # Molcas with optimisation and LibWFA support. Note, that this disables

--- a/pkgs/by-name/exchcxx/package.nix
+++ b/pkgs/by-name/exchcxx/package.nix
@@ -1,0 +1,82 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, symlinkJoin
+, cmake
+, libxc
+, cfg
+, enableCuda ? cfg.useCuda
+, cudaPackages
+, autoAddDriverRunpath
+, enableHip ? false
+, rocmPackages
+}:
+
+assert enableCuda -> !enableHip;
+
+let
+  rocmMerged = symlinkJoin {
+    name = "rocm-merged";
+
+    paths = with rocmPackages; [
+      clr
+      rocm-comgr
+      rocm-device-libs
+      rocm-runtime
+      clr.icd
+    ];
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "ExchCXX";
+  version = "unstable-2024-07-28";
+
+  # Upstream version is from wavefunction91, but has HIP bugs not fixed yet
+  src = fetchFromGitHub {
+    owner = "ryanstocks00";
+    repo = pname;
+    rev = "8a0004609afc710bdad4367867026a9daa0a758b";
+    hash = "sha256-38jicRJzoTKM1wIm2rj++4mUPCUwW6ZYvmNepkFlG0Y=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ] ++ lib.optional (enableCuda || enableHip) autoAddDriverRunpath;
+
+  buildInputs = lib.optionals enableCuda
+    (with cudaPackages; [
+      cudatoolkit
+      cuda_cudart
+    ]) ++ lib.optionals enableHip [
+      rocmMerged
+    ];
+
+  # Yes, really. This needs to be propagated. Otherwise downstream CMake will
+  # complain when trying to find ExchCXX.
+  propagatedBuildInputs = [
+    libxc
+  ];
+
+  # Required to make the HIP compiler work in this CMake setup
+  preConfigure = lib.strings.optionalString enableHip ''
+    export ROCM_PATH=${rocmMerged}
+  '';
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+    (cmakeBool "EXCHCXX_ENABLE_CUDA" enableCuda)
+    (cmakeBool "EXCHCXX_ENABLE_HIP" enableHip)
+  ];
+
+  # Checks with accelerators don't work in the sandbox
+  doCheck = !enableCuda && !enableHip;
+
+  meta = with lib; {
+    description = "Exchange correlation library for density functional theory calculations";
+    homepage = "https://github.com/wavefunction91/ExchCXX";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/by-name/gauxc/CmakeConfig.patch
+++ b/pkgs/by-name/gauxc/CmakeConfig.patch
@@ -1,0 +1,13 @@
+diff --git a/cmake/gauxc-config.cmake.in b/cmake/gauxc-config.cmake.in
+index 648192f..df7968f 100644
+--- a/cmake/gauxc-config.cmake.in
++++ b/cmake/gauxc-config.cmake.in
+@@ -63,7 +63,7 @@ if( GAUXC_HAS_HIP )
+   find_package( hipblas REQUIRED )
+ 
+   list(REMOVE_AT CMAKE_PREFIX_PATH 0 1 2)
+-endif
++endif()
+ 
+ if( GAUXC_HAS_MPI )
+   find_dependency( MPI )

--- a/pkgs/by-name/gauxc/DynamicLinking.patch
+++ b/pkgs/by-name/gauxc/DynamicLinking.patch
@@ -1,0 +1,13 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index c733ec9..752bfcc 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -28,7 +28,7 @@ include( gauxc-integratorxx )
+ include( gauxc-exchcxx      )
+ 
+ 
+-add_library( gauxc STATIC 
++add_library( gauxc 
+   grid.cxx 
+   grid_impl.cxx 
+   grid_factory.cxx

--- a/pkgs/by-name/gauxc/HighFive.patch
+++ b/pkgs/by-name/gauxc/HighFive.patch
@@ -1,0 +1,51 @@
+diff --git a/src/external/CMakeLists.txt b/src/external/CMakeLists.txt
+index 3df13b3..3f7bd62 100644
+--- a/src/external/CMakeLists.txt
++++ b/src/external/CMakeLists.txt
+@@ -11,19 +11,26 @@ if( GAUXC_ENABLE_HDF5 )
+   if(HDF5_FOUND)
+     set(GAUXC_HAS_HDF5 TRUE CACHE BOOL "" FORCE)
+     message(STATUS "Enabling HDF5 Bindings")
+-    message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
+-    message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
+-    FetchContent_Declare( HighFive
+-      GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
+-      GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
+-    )
+-    
+-    set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
+-    set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
+-    set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
+-    #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
+-    set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
+-    FetchContent_MakeAvailable( HighFive )
++
++    find_package(HighFive)
++    if(HighFive_FOUND)
++      message(STATUS "Found installed HighFive")
++    else()
++      message(STATUS "HighFive not found, fetching from repository")
++      message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
++      message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
++      FetchContent_Declare( HighFive
++        GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
++        GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
++      )
++      
++      set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
++      set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
++      set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
++      #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
++      set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
++      FetchContent_MakeAvailable( HighFive )
++    endif()
+     
+     target_sources( gauxc PRIVATE hdf5_write.cxx hdf5_read.cxx )
+     target_link_libraries( gauxc PUBLIC HighFive )
+@@ -32,4 +39,4 @@ if( GAUXC_ENABLE_HDF5 )
+   endif()
+ else()
+   message(STATUS "Disabling HDF5 Bindings")
+-endif()
++endif()
+\ No newline at end of file

--- a/pkgs/by-name/gauxc/Linalg.patch
+++ b/pkgs/by-name/gauxc/Linalg.patch
@@ -1,0 +1,44 @@
+diff --git a/cmake/gauxc-linalg-modules.cmake b/cmake/gauxc-linalg-modules.cmake
+index 69a69a7..8640328 100644
+--- a/cmake/gauxc-linalg-modules.cmake
++++ b/cmake/gauxc-linalg-modules.cmake
+@@ -1,11 +1,18 @@
+ include( FetchContent )
+ include( gauxc-dep-versions )
+-FetchContent_Declare( linalg-cmake-modules 
+-  GIT_REPOSITORY ${GAUXC_LINALG_MODULES_REPOSITORY} 
+-  GIT_TAG        ${GAUXC_LINALG_MODULES_REVISION} 
+-)
+-FetchContent_GetProperties( linalg-cmake-modules )
+-if( NOT linalg-cmake-modules_POPULATED )
+-  FetchContent_Populate( linalg-cmake-modules )
+-  list( PREPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
+-endif()
++
++set(LINALG_CMAKE_MODULES_DIR @LINALG_CMAKE_MODULES_DIR@)
++
++if(EXISTS ${LINALG_CMAKE_MODULES_DIR})
++  list(PREPEND CMAKE_MODULE_PATH ${LINALG_CMAKE_MODULES_DIR})
++else()
++  FetchContent_Declare( linalg-cmake-modules 
++    GIT_REPOSITORY ${GAUXC_LINALG_MODULES_REPOSITORY} 
++    GIT_TAG        ${GAUXC_LINALG_MODULES_REVISION} 
++  )
++  FetchContent_GetProperties( linalg-cmake-modules )
++  if( NOT linalg-cmake-modules_POPULATED )
++    FetchContent_Populate( linalg-cmake-modules )
++    list( PREPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
++  endif()
++endif()
+\ No newline at end of file
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 7e51e9f..c733ec9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -222,5 +222,5 @@ install( FILES
+ )
+ 
+ # Install Custom Find Modules
+-include( ${linalg-cmake-modules_SOURCE_DIR}/LinAlgModulesMacros.cmake )
++include( @LINALG_CMAKE_MODULES_DIR@/LinAlgModulesMacros.cmake )
+ install_linalg_modules( INSTALL_CONFIGDIR )

--- a/pkgs/by-name/gauxc/TestSerial.patch
+++ b/pkgs/by-name/gauxc/TestSerial.patch
@@ -1,0 +1,10 @@
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index d3881e9..2a9b664 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -94,4 +94,5 @@ if( GAUXC_ENABLE_MPI )
+   add_test( NAME GAUXC_MPI_TEST
+             COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} $<TARGET_FILE:gauxc_test> ${MPIEXEC_POSTFLAGS}
+   )
++  set_tests_properties(GAUXC_SERIAL_TEST GAUXC_MPI_TEST PROPERTIES RUN_SERIAL TRUE)
+ endif()

--- a/pkgs/by-name/gauxc/cmake.patch
+++ b/pkgs/by-name/gauxc/cmake.patch
@@ -1,0 +1,104 @@
+diff --git a/cmake/gauxc-linalg-modules.cmake b/cmake/gauxc-linalg-modules.cmake
+index 69a69a7..8640328 100644
+--- a/cmake/gauxc-linalg-modules.cmake
++++ b/cmake/gauxc-linalg-modules.cmake
+@@ -1,11 +1,18 @@
+ include( FetchContent )
+ include( gauxc-dep-versions )
+-FetchContent_Declare( linalg-cmake-modules 
+-  GIT_REPOSITORY ${GAUXC_LINALG_MODULES_REPOSITORY} 
+-  GIT_TAG        ${GAUXC_LINALG_MODULES_REVISION} 
+-)
+-FetchContent_GetProperties( linalg-cmake-modules )
+-if( NOT linalg-cmake-modules_POPULATED )
+-  FetchContent_Populate( linalg-cmake-modules )
+-  list( PREPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
+-endif()
++
++set(LINALG_CMAKE_MODULES_DIR @LINALG_CMAKE_MODULES_DIR@)
++
++if(EXISTS ${LINALG_CMAKE_MODULES_DIR})
++  list(PREPEND CMAKE_MODULE_PATH ${LINALG_CMAKE_MODULES_DIR})
++else()
++  FetchContent_Declare( linalg-cmake-modules 
++    GIT_REPOSITORY ${GAUXC_LINALG_MODULES_REPOSITORY} 
++    GIT_TAG        ${GAUXC_LINALG_MODULES_REVISION} 
++  )
++  FetchContent_GetProperties( linalg-cmake-modules )
++  if( NOT linalg-cmake-modules_POPULATED )
++    FetchContent_Populate( linalg-cmake-modules )
++    list( PREPEND CMAKE_MODULE_PATH ${linalg-cmake-modules_SOURCE_DIR} )
++  endif()
++endif()
+\ No newline at end of file
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 7e51e9f..752bfcc 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -28,7 +28,7 @@ include( gauxc-integratorxx )
+ include( gauxc-exchcxx      )
+ 
+ 
+-add_library( gauxc STATIC 
++add_library( gauxc 
+   grid.cxx 
+   grid_impl.cxx 
+   grid_factory.cxx
+@@ -222,5 +222,5 @@ install( FILES
+ )
+ 
+ # Install Custom Find Modules
+-include( ${linalg-cmake-modules_SOURCE_DIR}/LinAlgModulesMacros.cmake )
++include( @LINALG_CMAKE_MODULES_DIR@/LinAlgModulesMacros.cmake )
+ install_linalg_modules( INSTALL_CONFIGDIR )
+diff --git a/src/external/CMakeLists.txt b/src/external/CMakeLists.txt
+index 3df13b3..3f7bd62 100644
+--- a/src/external/CMakeLists.txt
++++ b/src/external/CMakeLists.txt
+@@ -11,19 +11,26 @@ if( GAUXC_ENABLE_HDF5 )
+   if(HDF5_FOUND)
+     set(GAUXC_HAS_HDF5 TRUE CACHE BOOL "" FORCE)
+     message(STATUS "Enabling HDF5 Bindings")
+-    message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
+-    message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
+-    FetchContent_Declare( HighFive
+-      GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
+-      GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
+-    )
+-    
+-    set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
+-    set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
+-    set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
+-    #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
+-    set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
+-    FetchContent_MakeAvailable( HighFive )
++
++    find_package(HighFive)
++    if(HighFive_FOUND)
++      message(STATUS "Found installed HighFive")
++    else()
++      message(STATUS "HighFive not found, fetching from repository")
++      message(STATUS "HighFive REPO = ${GAUXC_HIGHFIVE_REPOSITORY}")
++      message(STATUS "HighFive REV  = ${GAUXC_HIGHFIVE_REVISION}  ")
++      FetchContent_Declare( HighFive
++        GIT_REPOSITORY ${GAUXC_HIGHFIVE_REPOSITORY}
++        GIT_TAG        ${GAUXC_HIGHFIVE_REVISION}  
++      )
++      
++      set(HIGHFIVE_USE_BOOST OFF CACHE BOOL "" )
++      set(HIGHFIVE_UNIT_TESTS OFF CACHE BOOL "" )
++      set(HIGHFIVE_EXAMPLES OFF CACHE BOOL "" )
++      #set(HIGHFIVE_PARALLEL_HDF5 ON CACHE BOOL "" )
++      set(HIGHFIVE_BUILD_DOCS OFF CACHE BOOL "" )
++      FetchContent_MakeAvailable( HighFive )
++    endif()
+     
+     target_sources( gauxc PRIVATE hdf5_write.cxx hdf5_read.cxx )
+     target_link_libraries( gauxc PUBLIC HighFive )
+@@ -32,4 +39,4 @@ if( GAUXC_ENABLE_HDF5 )
+   endif()
+ else()
+   message(STATUS "Disabling HDF5 Bindings")
+-endif()
++endif()
+\ No newline at end of file

--- a/pkgs/by-name/gauxc/package.nix
+++ b/pkgs/by-name/gauxc/package.nix
@@ -1,0 +1,158 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, symlinkJoin
+, cmake
+, mpi
+, blas
+, gau2grid
+, integratorxx
+, exchcxx
+, hdf5-mpi
+, highfive-mpi
+, eigen
+, catch2
+, cereal
+, mpiCheckPhaseHook
+, pkg-config
+, cfg
+, autoAddDriverRunpath
+, enableCuda ? cfg.useCuda
+  # CUDA compute capability. 60 is the minimum required by GauXC. Set according to GPU.
+, cudaArchitecture ? "60"
+, cudaPackages
+, magma-cuda
+, enableHip ? false
+, rocmPackages
+, magma-hip
+}:
+
+assert enableCuda -> !enableHip;
+
+let
+  linalgCmake = fetchFromGitHub {
+    owner = "wavefunction91";
+    repo = "linalg-cmake-modules";
+    rev = "28ceaa9738f14935aa544289fa2fe4c4cc955d0e";
+    hash = "sha256-EGPubUYlZjgJRnUdtgCG+aKcmkpQk1m9N3VVYMgIwic=";
+  };
+
+  rocmMerged = symlinkJoin {
+    name = "rocm-merged";
+
+    paths = with rocmPackages; [
+      clr
+      rocm-comgr
+      rocm-device-libs
+      rocm-runtime
+      rocprim
+      hipsparse
+      hipblas
+      hipcub
+      clr.icd
+    ];
+  };
+
+in
+stdenv.mkDerivation rec {
+  pname = "GauXC";
+  version = "unstable-2024-09-30";
+
+  # Upstream version is from wavefunction91, but has HIP bugs not fixed yet
+  src = fetchFromGitHub {
+    owner = "ryanstocks00";
+    repo = pname;
+    rev = "ecf6eacc411a4cfe09e6f8e5b3b2855264e0ffb7";
+    hash = "sha256-uqVkQfn5UWxJq3DUnxgkoIfEflU/kQXyvJZlmeQk+pM=";
+  };
+
+  patches = [
+    # Uses a a local clone of the linalg-cmake-modules repository instead of fetching it.
+    # Substitute @LINALG_CMAKE_MODULES_DIR@ with the path to the prefetched linalg-cmake-modules repository.
+    ./Linalg.patch
+
+    # Allows usage of a installed HighFive version instead of fetching it
+    ./HighFive.patch
+
+    # Removes the hardcoded forced static linking
+    ./DynamicLinking.patch
+
+    # Forces the MPI tests to strictly run after the serial tests. Otherwise,
+    # both will occasionally try to write to the same file at the same time.
+    ./TestSerial.patch
+
+    # Upstreams config-cmake has a syntax error, so that GauXC cannot be found
+    # as dependency by other projects. This patch fixes the syntax error.
+    ./CmakeConfig.patch
+  ];
+
+  postPatch = ''
+    substituteInPlace cmake/gauxc-linalg-modules.cmake src/CMakeLists.txt \
+      --subst-var-by "LINALG_CMAKE_MODULES_DIR" "${linalgCmake}"
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ] ++ lib.optional (enableCuda || enableHip) autoAddDriverRunpath;
+
+  buildInputs = [
+    hdf5-mpi
+  ] ++ lib.optionals enableCuda (with cudaPackages; [
+    libcublas
+    cuda_nvcc
+    cuda_cudart
+    cuda_cccl
+    libcusparse
+    magma-cuda
+  ]) ++ lib.optionals enableHip [
+    rocmMerged
+    magma-hip
+  ];
+
+  propagatedBuildInputs = [
+    highfive-mpi
+    gau2grid
+    integratorxx
+    exchcxx
+    blas
+    mpi
+  ];
+
+  # Interestingly the ROCM_PATH must be set both as environment variable and
+  # passed to CMake to make HIP work. One is not enough.
+  preConfigure = lib.optionalString enableHip ''
+    export ROCM_PATH=${rocmMerged}
+  '';
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "GAUXC_ENABLE_MPI" true)
+    (cmakeBool "GAUXC_ENABLE_OPENMP" true)
+    (cmakeBool "GAUXC_ENABLE_CUDA" enableCuda)
+    (cmakeBool "GAUXC_ENABLE_HIP" enableHip)
+  ] ++ lib.optionals enableCuda [
+    (cmakeFeature "CMAKE_CUDA_ARCHITECTURES" cudaArchitecture)
+  ] ++ lib.optionals enableHip [
+    (cmakeFeature "ROCM_PATH" (builtins.toString rocmMerged))
+  ];
+
+
+  # Checks with accelerators don't work in the sandbox
+  doCheck = !enableCuda && !enableHip;
+
+  nativeCheckInputs = [ mpiCheckPhaseHook ];
+
+  checkInputs = [
+    eigen
+    catch2
+    cereal
+  ];
+
+  meta = with lib; {
+    description = "Evaluation of quantities related to the exchange-correlation energy (e.g. potential, etc) in the Gaussian basis set discretization of Kohn-Sham density function theory";
+    homepage = "https://github.com/wavefunction91/GauXC";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}

--- a/pkgs/by-name/integratorxx/package.nix
+++ b/pkgs/by-name/integratorxx/package.nix
@@ -1,0 +1,38 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+, catch2_3
+}:
+
+stdenv.mkDerivation rec {
+  pname = "IntegratorXX";
+  version = "unstable-2023-08-10";
+
+  src = fetchFromGitHub {
+    owner = "wavefunction91";
+    repo = pname;
+    rev = "ea07dedd37e7bd49ea06394eb811599002b34b49";
+    hash = "sha256-L9IuzkvQGxfUJ+7x63IxETfvIwCCcxWW9AXUKTnKMYY=";
+  };
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  cmakeFlags = with lib.strings; [
+    (cmakeBool "BUILD_SHARED_LIBS" (!stdenv.hostPlatform.isStatic))
+  ];
+
+  checkInputs = [ catch2_3 ];
+
+  doCheck = true;
+
+  meta = with lib; {
+    description = "Reusable DFT Grids for the Masses";
+    homepage = "https://github.com/wavefunction91/IntegratorXX";
+    license = licenses.bsd3;
+    platforms = [ "x86_64-linux" ];
+    maintainers = [ maintainers.sheepforce ];
+  };
+}


### PR DESCRIPTION
This adds a series of high-performance DFT-related libraries with GPU support. Especially GauXC requires tons of patching to avoid on-the-fly downloads, broken HIP builds, incorrect configure files and tests that crash each other when running concurrently.