### PR TITLE
ignore dangling symlinks

### DIFF
--- a/pkgs/by-name/dice/package.nix
+++ b/pkgs/by-name/dice/package.nix
@@ -52,6 +52,10 @@ stdenv.mkDerivation {
     runHook postInstall
   '';
 
+  # Some example files are broken symlinks. They are not problematic for runtime
+  # behaviour.
+  dontCheckForBrokenSymlinks = true;
+
   passthru = { inherit mpi; };
 
   meta = with lib; {

--- a/pkgs/python-by-name/ambertools/package.nix
+++ b/pkgs/python-by-name/ambertools/package.nix
@@ -135,6 +135,10 @@ buildPythonPackage rec {
       runHook postInstall
     '';
 
+  # There is a force field alias to a non-existing force field in the test leaprc
+  # It is shipped like this in the official tarball.
+  dontCheckForBrokenSymlinks = true;
+
   meta = with lib; {
     description = "Tools for molecular mechanics and molecular dynamics with AMBER";
     homepage = "https://ambermd.org/AmberTools.php";


### PR DESCRIPTION
Fixes #619 (dice and ambertools). Both packages have dangling symlinks to some parameter or example files. I simply ignore these issues by setting `dontCheckForBrokenSymlinks = true;` as they are already missing upstream and are not a result of packaging.