### PR TITLE
multiwfn: 3.8-2024-06-14 -> 3.8-2025-03-31

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743320628,
-        "narHash": "sha256-FurMxmjEEqEMld11eX2vgfAx0Rz0JhoFm8UgxbfCZa8=",
+        "lastModified": 1743689281,
+        "narHash": "sha256-y7Hg5lwWhEOgflEHRfzSH96BOt26LaYfrYWzZ+VoVdg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63158b9cbb6ec93d26255871c447b0f01da81619",
+        "rev": "2bfc080955153be0be56724be6fa5477b4eefabb",
         "type": "github"
       },
       "original": {

--- a/pkgs/apps/pegamoid/default.nix
+++ b/pkgs/apps/pegamoid/default.nix
@@ -1,5 +1,5 @@
 { buildPythonApplication
-, python3
+, python
 , fetchFromGitLab
 , lib
 , numpy
@@ -28,7 +28,7 @@ buildPythonApplication rec {
   prePatch = "rm -rf samples screenshots";
 
   preConfigure = ''
-    export PYTHONPATH=$PYTHONPATH:${vtk}/${python3.sitePackages}
+    export PYTHONPATH=$PYTHONPATH:${vtk}/${python.sitePackages}
   '';
 
   propagatedBuildInputs = [

--- a/pkgs/by-name/multiwfn/package.nix
+++ b/pkgs/by-name/multiwfn/package.nix
@@ -7,19 +7,18 @@
 , libGL
 , motif
 , mkl
-, arb
 , flint
 }:
 
 stdenv.mkDerivation rec {
   pname = "multiwfn";
-  version = "3.8-2024-06-14";
+  version = "3.8-2025-03-31";
 
   src = fetchFromGitLab {
     owner = "theoretical-chemistry-jena/quantum-chemistry";
     repo = pname;
-    rev = "2aa317686863ef06d7abfc0a259009262e994d76";
-    hash = "sha256-xwU7a9b3jcHidYxSAKyEzRgdCMyDvxxeXr7oa6F/Jj0=";
+    rev = "736fcdd2b2342df78c6c2c910e2e2643683991e9";
+    hash = "sha256-o3mAG+0YVXdmSkpETzvM1tWY97b+GDk4MM2jCJKlyUE=";
   };
 
   preConfigure = "cd src";
@@ -35,7 +34,6 @@ stdenv.mkDerivation rec {
     libGL
     motif
     mkl
-    arb
     flint
   ];
 


### PR DESCRIPTION
Fixes #656 
In nixpkgs-unstable, `flint3` is actually `flint` and `flint2` is the extra value. To be merged together with a flake update.