### PR TITLE
flake: fix clean up package of set

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,9 +52,12 @@
         let
           buildingPkgs = filterAttrs
             (k: v:
-              if (v ? meta.broken)
-              then !v.meta.broken && isDerivation v
-              else isDerivation v
+              if (builtins.tryEval v).success
+              then
+                if (v ? meta.broken)
+                then !v.meta.broken && isDerivation v
+                else isDerivation v
+              else false
             )
             pkgs.qchem;
           securePackages = builtins.removeAttrs buildingPkgs [ "python2" ];


### PR DESCRIPTION
Closes https://github.com/Nix-QChem/NixOS-QChem/issues/674

The cleanup  leads to failure of all packages when evaluation of one fails.

