### PR TITLE
et: add reduced mass patch

### DIFF
--- a/pkgs/by-name/et/package.nix
+++ b/pkgs/by-name/et/package.nix
@@ -34,7 +34,10 @@ stdenv.mkDerivation (final: {
     hash = "sha256-JjWBvpna4Dx8FgVA/nalTwA8PPByd2ErAe0xUN89wYg=";
   };
 
-  patches = [ ./argparse.patch ];
+  patches = [
+    ./argparse.patch
+    ./reduced_mass.patch
+  ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/et/reduced_mass.patch
+++ b/pkgs/by-name/et/reduced_mass.patch
@@ -1,0 +1,35 @@
+diff --git a/src/engines/harmonic_frequencies_engine_class.F90 b/src/engines/harmonic_frequencies_engine_class.F90
+index 23810f5e2..fc11b7f75 100644
+--- a/src/engines/harmonic_frequencies_engine_class.F90
++++ b/src/engines/harmonic_frequencies_engine_class.F90
+@@ -735,6 +735,7 @@ contains
+       integer :: mode_, atom
+ 
+       real(dp), dimension(:, :), allocatable :: Q
++      real(dp) :: l2_norm
+ 
+       call output%printf('m', '- Normal modes', fs='(/t3,a/)')
+ 
+@@ -752,12 +753,19 @@ contains
+          call output%printf('m', &
+                             'Frequency (cm-1): (c17.12)', &
+                             complexs=[this%frequencies(mode_)], &
+-                            fs='(t6,a/)')
++                            fs='(t6,a)')
+ 
+-         call output%printf('m', 'Normal mode geometry:', fs='(t6,a/)')
+ 
+          Q = this%normal_modes(:, :, mode_)
+-         Q = Q / get_l2_norm(Q, 3 * this%n_atoms)
++         l2_norm = get_l2_norm(Q, 3 * this%n_atoms)
++         Q = Q / l2_norm
++
++         call output%printf('m', &
++                            'Reduced mass (au): (f19.3)', &
++                            reals=[1.0/l2_norm/l2_norm], &
++                            fs='(t6,a/)')
++
++         call output%printf('m', 'Normal mode geometry:', fs='(t6,a/)')
+ 
+          do atom = 1, this%n_atoms
+ 


### PR DESCRIPTION
eT does not show the reduced masses of normal modes, but outputs normalized displacement vectors.